### PR TITLE
Fix "Consider dict comprehensions instead of using 'dict()'" issue

### DIFF
--- a/jython-installer/src/main/resources/Lib/site-packages/distribute-0.6.19-py2.5.egg/site.py
+++ b/jython-installer/src/main/resources/Lib/site-packages/distribute-0.6.19-py2.5.egg/site.py
@@ -39,7 +39,7 @@ def __boot():
 
     #print "loaded", __file__
 
-    known_paths = dict([(makepath(item)[1],1) for item in sys.path]) # 2.2 comp
+    known_paths = {makepath(item)[1]: 1 for item in sys.path} # 2.2 comp
 
     oldpos = getattr(sys,'__egginsert',0)   # save old insertion position
     sys.__egginsert = 0                     # and reset the current one


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Consider dict comprehensions instead of using 'dict()'](https://www.quantifiedcode.com/app/issue_class/539Wia7V)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:jython-plugin?groups=code_patterns/%3A539Wia7V](https://www.quantifiedcode.com/app/project/gh:runt18:jython-plugin?groups=code_patterns/%3A539Wia7V)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
