### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/jython-installer/src/main/resources/Lib/site-packages/distribute-0.6.19-py2.5.egg/pkg_resources.py
+++ b/jython-installer/src/main/resources/Lib/site-packages/distribute-0.6.19-py2.5.egg/pkg_resources.py
@@ -106,7 +106,7 @@ def get_supported_platform():
     plat = get_build_platform(); m = macosVersionString.match(plat)
     if m is not None and sys.platform == "darwin":
         try:
-            plat = 'macosx-%s-%s' % ('.'.join(_macosx_vers()[:2]), m.group(3))
+            plat = 'macosx-{0!s}-{1!s}'.format('.'.join(_macosx_vers()[:2]), m.group(3))
         except ValueError:
             pass    # not Mac OS X
     return plat
@@ -251,7 +251,7 @@ def get_build_platform():
         try:
             version = _macosx_vers()
             machine = os.uname()[4].replace(" ", "_")
-            return "macosx-%d.%d-%s" % (int(version[0]), int(version[1]),
+            return "macosx-{0:d}.{1:d}-{2!s}".format(int(version[0]), int(version[1]),
                 _macosx_arch(machine))
         except ValueError:
             # if someone is running a non-Mac darwin system, this will fall
@@ -286,7 +286,7 @@ def compatible_platforms(provided,required):
             provDarwin = darwinVersionString.match(provided)
             if provDarwin:
                 dversion = int(provDarwin.group(1))
-                macosversion = "%s.%s" % (reqMac.group(1), reqMac.group(2))
+                macosversion = "{0!s}.{1!s}".format(reqMac.group(1), reqMac.group(2))
                 if dversion == 7 and macosversion >= "10.3" or \
                     dversion == 8 and macosversion >= "10.4":
 
@@ -849,7 +849,7 @@ class Environment(object):
                 for dist in other[project]:
                     self.add(dist)
         else:
-            raise TypeError("Can't add %r to environment" % (other,))
+            raise TypeError("Can't add {0!r} to environment".format(other))
         return self
 
     def __add__(self, other):
@@ -933,16 +933,16 @@ class ResourceManager:
 The following error occurred while trying to extract file(s) to the Python egg
 cache:
 
-  %s
+  {0!s}
 
 The Python egg cache directory is currently set to:
 
-  %s
+  {1!s}
 
 Perhaps your account does not have write access to this directory?  You can
 change the cache directory by setting the PYTHON_EGG_CACHE environment
 variable to point to an accessible directory.
-"""         % (old_exc, cache_path)
+""".format(old_exc, cache_path)
         )
         err.manager        = self
         err.cache_path     = cache_path
@@ -1226,7 +1226,7 @@ class NullProvider:
     def run_script(self,script_name,namespace):
         script = 'scripts/'+script_name
         if not self.has_metadata(script):
-            raise ResolutionError("No script named %r" % script_name)
+            raise ResolutionError("No script named {0!r}".format(script_name))
         script_text = self.get_metadata(script).replace('\r\n','\n')
         script_text = script_text.replace('\r','\n')
         script_filename = self._fn(self.egg_info,script)
@@ -1354,7 +1354,7 @@ class ZipProvider(EggProvider):
         if fspath.startswith(self.zip_pre):
             return fspath[len(self.zip_pre):]
         raise AssertionError(
-            "%s is not a subpath of %s" % (fspath,self.zip_pre)
+            "{0!s} is not a subpath of {1!s}".format(fspath, self.zip_pre)
         )
 
     def _parts(self,zip_path):
@@ -1363,7 +1363,7 @@ class ZipProvider(EggProvider):
         if fspath.startswith(self.egg_root+os.sep):
             return fspath[len(self.egg_root)+1:].split(os.sep)
         raise AssertionError(
-            "%s is not a subpath of %s" % (fspath,self.egg_root)
+            "{0!s} is not a subpath of {1!s}".format(fspath, self.egg_root)
         )
 
     def get_resource_filename(self, manager, resource_name):
@@ -1972,19 +1972,19 @@ class EntryPoint(object):
         self.name = name
         self.module_name = module_name
         self.attrs = tuple(attrs)
-        self.extras = Requirement.parse(("x[%s]" % ','.join(extras))).extras
+        self.extras = Requirement.parse(("x[{0!s}]".format(','.join(extras)))).extras
         self.dist = dist
 
     def __str__(self):
-        s = "%s = %s" % (self.name, self.module_name)
+        s = "{0!s} = {1!s}".format(self.name, self.module_name)
         if self.attrs:
             s += ':' + '.'.join(self.attrs)
         if self.extras:
-            s += ' [%s]' % ','.join(self.extras)
+            s += ' [{0!s}]'.format(','.join(self.extras))
         return s
 
     def __repr__(self):
-        return "EntryPoint.parse(%r)" % str(self)
+        return "EntryPoint.parse({0!r})".format(str(self))
 
     def load(self, require=True, env=None, installer=None):
         if require: self.require(env, installer)
@@ -1993,7 +1993,7 @@ class EntryPoint(object):
             try:
                 entry = getattr(entry,attr)
             except AttributeError:
-                raise ImportError("%r has no %r attribute" % (entry,attr))
+                raise ImportError("{0!r} has no {1!r} attribute".format(entry, attr))
         return entry
 
     def require(self, env=None, installer=None):
@@ -2214,7 +2214,7 @@ class Distribution(object):
                 deps.extend(dm[safe_extra(ext)])
             except KeyError:
                 raise UnknownExtra(
-                    "%s has no such extra feature %r" % (self, ext)
+                    "{0!s} has no such extra feature {1!r}".format(self, ext)
                 )
         return deps
 
@@ -2234,7 +2234,7 @@ class Distribution(object):
 
     def egg_name(self):
         """Return what this distribution's standard .egg filename should be"""
-        filename = "%s-%s-py%s" % (
+        filename = "{0!s}-{1!s}-py{2!s}".format(
             to_filename(self.project_name), to_filename(self.version),
             self.py_version or PY_MAJOR
         )
@@ -2245,7 +2245,7 @@ class Distribution(object):
 
     def __repr__(self):
         if self.location:
-            return "%s (%s)" % (self,self.location)
+            return "{0!s} ({1!s})".format(self, self.location)
         else:
             return str(self)
 
@@ -2253,7 +2253,7 @@ class Distribution(object):
         try: version = getattr(self,'version',None)
         except ValueError: version = None
         version = version or "[unknown version]"
-        return "%s %s" % (self.project_name,version)
+        return "{0!s} {1!s}".format(self.project_name, version)
 
     def __getattr__(self,attr):
         """Delegate all unrecognized public attributes to .metadata provider"""
@@ -2271,13 +2271,13 @@ class Distribution(object):
 
     def as_requirement(self):
         """Return a ``Requirement`` that matches this distribution exactly"""
-        return Requirement.parse('%s==%s' % (self.project_name, self.version))
+        return Requirement.parse('{0!s}=={1!s}'.format(self.project_name, self.version))
 
     def load_entry_point(self, group, name):
         """Return the `name` entry point of `group` or raise ImportError"""
         ep = self.get_entry_info(group,name)
         if ep is None:
-            raise ImportError("Entry point %r not found" % ((group,name),))
+            raise ImportError("Entry point {0!r} not found".format((group,name)))
         return ep.load()
 
     def get_entry_map(self, group=None):
@@ -2550,8 +2550,8 @@ class Requirement:
     def __str__(self):
         specs = ','.join([''.join(s) for s in self.specs])
         extras = ','.join(self.extras)
-        if extras: extras = '[%s]' % extras
-        return '%s%s%s' % (self.project_name, extras, specs)
+        if extras: extras = '[{0!s}]'.format(extras)
+        return '{0!s}{1!s}{2!s}'.format(self.project_name, extras, specs)
 
     def __eq__(self,other):
         return isinstance(other,Requirement) and self.hashCmp==other.hashCmp
@@ -2577,7 +2577,7 @@ class Requirement:
     def __hash__(self):
         return self.__hash
 
-    def __repr__(self): return "Requirement.parse(%r)" % str(self)
+    def __repr__(self): return "Requirement.parse({0!r})".format(str(self))
 
     #@staticmethod
     def parse(s, replacement=True):

--- a/jython-installer/src/main/resources/Lib/site-packages/distribute-0.6.19-py2.5.egg/setuptools/archive_util.py
+++ b/jython-installer/src/main/resources/Lib/site-packages/distribute-0.6.19-py2.5.egg/setuptools/archive_util.py
@@ -71,7 +71,7 @@ def unpack_archive(filename, extract_dir, progress_filter=default_filter,
             return
     else:
         raise UnrecognizedFormat(
-            "Not a recognized archive type: %s" % filename
+            "Not a recognized archive type: {0!s}".format(filename)
         )
 
 
@@ -86,7 +86,7 @@ def unpack_directory(filename, extract_dir, progress_filter=default_filter):
     Raises ``UnrecognizedFormat`` if `filename` is not a directory
     """
     if not os.path.isdir(filename):
-        raise UnrecognizedFormat("%s is not a directory" % (filename,))
+        raise UnrecognizedFormat("{0!s} is not a directory".format(filename))
 
     paths = {filename:('',extract_dir)}
     for base, dirs, files in os.walk(filename):
@@ -130,7 +130,7 @@ def unpack_zipfile(filename, extract_dir, progress_filter=default_filter):
     """
 
     if not zipfile.is_zipfile(filename):
-        raise UnrecognizedFormat("%s is not a zip file" % (filename,))
+        raise UnrecognizedFormat("{0!s} is not a zip file".format(filename))
 
     z = zipfile.ZipFile(filename)
     try:
@@ -174,7 +174,7 @@ def unpack_tarfile(filename, extract_dir, progress_filter=default_filter):
         tarobj = tarfile.open(filename)
     except tarfile.TarError:
         raise UnrecognizedFormat(
-            "%s is not a compressed or uncompressed tar file" % (filename,)
+            "{0!s} is not a compressed or uncompressed tar file".format(filename)
         )
 
     try:

--- a/jython-installer/src/main/resources/Lib/site-packages/distribute-0.6.19-py2.5.egg/setuptools/command/alias.py
+++ b/jython-installer/src/main/resources/Lib/site-packages/distribute-0.6.19-py2.5.egg/setuptools/command/alias.py
@@ -57,7 +57,7 @@ class alias(option_base):
                 print "setup.py alias", format_alias(alias, aliases)
                 return
             else:
-                print "No alias definition found for %r" % alias
+                print "No alias definition found for {0!r}".format(alias)
                 return
         else:
             alias = self.args[0]
@@ -75,7 +75,7 @@ def format_alias(name, aliases):
     elif source == config_file('local'):
         source = ''
     else:
-        source = '--filename=%r' % source
+        source = '--filename={0!r}'.format(source)
     return source+name+' '+command
             
 

--- a/jython-installer/src/main/resources/Lib/site-packages/distribute-0.6.19-py2.5.egg/setuptools/command/bdist_egg.py
+++ b/jython-installer/src/main/resources/Lib/site-packages/distribute-0.6.19-py2.5.egg/setuptools/command/bdist_egg.py
@@ -32,8 +32,7 @@ def write_stub(resource, pyfile):
         "def __bootstrap__():",
         "   global __bootstrap__, __loader__, __file__",
         "   import sys, pkg_resources, imp",
-        "   __file__ = pkg_resources.resource_filename(__name__,%r)"
-            % resource,
+        "   __file__ = pkg_resources.resource_filename(__name__,{0!r})".format(resource),
         "   __loader__ = None; del __bootstrap__, __loader__",
         "   imp.load_dynamic(__name__,__file__)",
         "__bootstrap__()",
@@ -146,7 +145,7 @@ class bdist_egg(Command):
             self.distribution.data_files.append(item)
 
         try:
-            log.info("installing package data to %s" % self.bdist_dir)
+            log.info("installing package data to {0!s}".format(self.bdist_dir))
             self.call_command('install_data', force=0, root=None)
         finally:
             self.distribution.data_files = old
@@ -173,7 +172,7 @@ class bdist_egg(Command):
 
         # We run install_lib before install_data, because some data hacks
         # pull their data path from the install_lib command.
-        log.info("installing library code to %s" % self.bdist_dir)
+        log.info("installing library code to {0!s}".format(self.bdist_dir))
         instcmd = self.get_finalized_command('install')
         old_root = instcmd.root; instcmd.root = None
         cmd = self.call_command('install_lib', warn_dir=0)
@@ -186,7 +185,7 @@ class bdist_egg(Command):
             filename,ext = os.path.splitext(ext_name)
             pyfile = os.path.join(self.bdist_dir, strip_module(filename)+'.py')
             self.stubs.append(pyfile)
-            log.info("creating stub loader for %s" % ext_name)
+            log.info("creating stub loader for {0!s}".format(ext_name))
             if not self.dry_run:
                 write_stub(os.path.basename(ext_name), pyfile)
             to_compile.append(pyfile)
@@ -205,13 +204,13 @@ class bdist_egg(Command):
         self.mkpath(egg_info)
         if self.distribution.scripts:
             script_dir = os.path.join(egg_info, 'scripts')
-            log.info("installing scripts to %s" % script_dir)
+            log.info("installing scripts to {0!s}".format(script_dir))
             self.call_command('install_scripts',install_dir=script_dir,no_ep=1)
 
         self.copy_metadata_to(egg_info)
         native_libs = os.path.join(egg_info, "native_libs.txt")
         if all_outputs:
-            log.info("writing %s" % native_libs)
+            log.info("writing {0!s}".format(native_libs))
             if not self.dry_run:
                 ensure_directory(native_libs)
                 libs_file = open(native_libs, 'wt')
@@ -219,7 +218,7 @@ class bdist_egg(Command):
                 libs_file.write('\n')
                 libs_file.close()
         elif os.path.isfile(native_libs):
-            log.info("removing %s" % native_libs)
+            log.info("removing {0!s}".format(native_libs))
             if not self.dry_run:
                 os.unlink(native_libs)
 
@@ -526,7 +525,7 @@ def make_zipfile(zip_filename, base_dir, verbose=0, dry_run=0, compress=None,
                 p = path[len(base_dir)+1:]
                 if not dry_run:
                     z.write(path, p)
-                log.debug("adding '%s'" % p)
+                log.debug("adding '{0!s}'".format(p))
 
     if compress is None:
         compress = (sys.version>="2.4") # avoid 2.3 zipimport bug when 64 bits

--- a/jython-installer/src/main/resources/Lib/site-packages/distribute-0.6.19-py2.5.egg/setuptools/command/bdist_wininst.py
+++ b/jython-installer/src/main/resources/Lib/site-packages/distribute-0.6.19-py2.5.egg/setuptools/command/bdist_wininst.py
@@ -9,8 +9,7 @@ class bdist_wininst(_bdist_wininst):
 
         if self.target_version:
             installer_name = os.path.join(self.dist_dir,
-                                          "%s.win32-py%s.exe" %
-                                           (fullname, self.target_version))
+                                          "{0!s}.win32-py{1!s}.exe".format(fullname, self.target_version))
             pyversion = self.target_version
 
             # fix 2.5 bdist_wininst ignoring --target-version spec
@@ -19,7 +18,7 @@ class bdist_wininst(_bdist_wininst):
                 dist_files.remove(bad)
         else:
             installer_name = os.path.join(self.dist_dir,
-                                          "%s.win32.exe" % fullname)
+                                          "{0!s}.win32.exe".format(fullname))
             pyversion = 'any'
         good = ('bdist_wininst', pyversion, installer_name)
         if good not in dist_files:

--- a/jython-installer/src/main/resources/Lib/site-packages/distribute-0.6.19-py2.5.egg/setuptools/command/build_ext.py
+++ b/jython-installer/src/main/resources/Lib/site-packages/distribute-0.6.19-py2.5.egg/setuptools/command/build_ext.py
@@ -221,8 +221,7 @@ class build_ext(_build_ext):
                 "def __bootstrap__():",
                 "   global __bootstrap__, __file__, __loader__",
                 "   import sys, os, pkg_resources, imp"+if_dl(", dl"),
-                "   __file__ = pkg_resources.resource_filename(__name__,%r)"
-                   % os.path.basename(ext._file_name),
+                "   __file__ = pkg_resources.resource_filename(__name__,{0!r})".format(os.path.basename(ext._file_name)),
                 "   del __bootstrap__",
                 "   if '__loader__' in globals():",
                 "       del __loader__",

--- a/jython-installer/src/main/resources/Lib/site-packages/distribute-0.6.19-py2.5.egg/setuptools/command/build_py.py
+++ b/jython-installer/src/main/resources/Lib/site-packages/distribute-0.6.19-py2.5.egg/setuptools/command/build_py.py
@@ -251,11 +251,11 @@ def assert_relative(path):
     raise DistutilsSetupError(
 """Error: setup script specifies an absolute path:
 
-    %s
+    {0!s}
 
 setup() arguments must *always* be /-separated paths relative to the
 setup.py directory, *never* absolute paths.
-""" % path
+""".format(path)
     )
 
 

--- a/jython-installer/src/main/resources/Lib/site-packages/distribute-0.6.19-py2.5.egg/setuptools/command/develop.py
+++ b/jython-installer/src/main/resources/Lib/site-packages/distribute-0.6.19-py2.5.egg/setuptools/command/develop.py
@@ -40,8 +40,7 @@ class develop(easy_install):
         ei = self.get_finalized_command("egg_info")
         if ei.broken_egg_info:
             raise DistutilsError(
-            "Please rename %r to %r before using 'develop'"
-            % (ei.egg_info, ei.broken_egg_info)
+            "Please rename {0!r} to {1!r} before using 'develop'".format(ei.egg_info, ei.broken_egg_info)
             )
         self.args = [ei.egg_name]
 

--- a/jython-installer/src/main/resources/Lib/site-packages/distribute-0.6.19-py2.5.egg/setuptools/command/easy_install.py
+++ b/jython-installer/src/main/resources/Lib/site-packages/distribute-0.6.19-py2.5.egg/setuptools/command/easy_install.py
@@ -115,7 +115,7 @@ class easy_install(Command):
 
     if HAS_USER_SITE:
         user_options.append(('user', None,
-                             "install in user site-package '%s'" % site.USER_SITE))
+                             "install in user site-package '{0!s}'".format(site.USER_SITE)))
         boolean_options.append('user')
 
 
@@ -187,7 +187,7 @@ class easy_install(Command):
 
     def finalize_options(self):
         if self.version:
-            print 'distribute %s' % get_distribution('distribute').version
+            print 'distribute {0!s}'.format(get_distribution('distribute').version)
             sys.exit()
 
         py_version = sys.version.split()[0]
@@ -352,8 +352,8 @@ class easy_install(Command):
                 from distutils import file_util
                 self.execute(
                     file_util.write_file, (self.record, outputs),
-                    "writing list of installed files to '%s'" %
-                    self.record
+                    "writing list of installed files to '{0!s}'".format(
+                    self.record)
                 )
             self.warn_deprecated_options()
         finally:
@@ -368,7 +368,7 @@ class easy_install(Command):
             pid = os.getpid()
         except:
             pid = random.randint(0,sys.maxint)
-        return os.path.join(self.install_dir, "test-easy-install-%s" % pid)
+        return os.path.join(self.install_dir, "test-easy-install-{0!s}".format(pid))
 
     def warn_deprecated_options(self):
         if self.delete_conflicting or self.ignore_conflicts_at_my_risk:
@@ -426,13 +426,13 @@ class easy_install(Command):
 The following error occurred while trying to add or remove files in the
 installation directory:
 
-    %s
+    {0!s}
 
 The installation directory you specified (via --install-dir, --prefix, or
 the distutils default setting) was:
 
-    %s
-"""     % (sys.exc_info()[1], self.install_dir,)
+    {1!s}
+""".format(sys.exc_info()[1], self.install_dir)
 
         if not os.path.exists(self.install_dir):
             msg += """
@@ -478,7 +478,7 @@ Please make the appropriate changes for your system and try again.
             self.cant_write_to_target()
         else:
             try:
-                f.write("import os;open(%r,'w').write('OK')\n" % (ok_file,))
+                f.write("import os;open({0!r},'w').write('OK')\n".format(ok_file))
                 f.close(); f=None
                 executable = sys.executable
                 if os.name=='nt':
@@ -537,8 +537,7 @@ Please make the appropriate changes for your system and try again.
 
         if os.path.exists(os.path.join(self.build_directory, spec.key)):
             raise DistutilsArgError(
-                "%r already exists in %s; can't do a checkout there" %
-                (spec.key, self.build_directory)
+                "{0!r} already exists in {1!s}; can't do a checkout there".format(spec.key, self.build_directory)
             )
 
 
@@ -573,7 +572,7 @@ Please make the appropriate changes for your system and try again.
             )
 
             if dist is None:
-                msg = "Could not find suitable distribution for %r" % spec
+                msg = "Could not find suitable distribution for {0!r}".format(spec)
                 if self.always_copy:
                     msg+=" (--always-copy skips system and development eggs)"
                 raise DistutilsError(msg)
@@ -670,12 +669,11 @@ Please make the appropriate changes for your system and try again.
             )
         except DistributionNotFound, e:
             raise DistutilsError(
-                "Could not find required distribution %s" % e.args
+                "Could not find required distribution {0!s}".format(e.args)
             )
         except VersionConflict, e:
             raise DistutilsError(
-                "Installed distribution %s conflicts with requirement %s"
-                % e.args
+                "Installed distribution {0!s} conflicts with requirement {1!s}".format(*e.args)
             )
         if self.always_copy or self.always_copy_from:
             # Force all the relevant distros to be copied or activated
@@ -789,11 +787,11 @@ Please make the appropriate changes for your system and try again.
             setups = glob(os.path.join(setup_base, '*', 'setup.py'))
             if not setups:
                 raise DistutilsError(
-                    "Couldn't find a setup script in %s" % os.path.abspath(dist_filename)
+                    "Couldn't find a setup script in {0!s}".format(os.path.abspath(dist_filename))
                 )
             if len(setups)>1:
                 raise DistutilsError(
-                    "Multiple setup scripts in %s" % os.path.abspath(dist_filename)
+                    "Multiple setup scripts in {0!s}".format(os.path.abspath(dist_filename))
                 )
             setup_script = setups[0]
 
@@ -850,7 +848,7 @@ Please make the appropriate changes for your system and try again.
         cfg = extract_wininst_cfg(dist_filename)
         if cfg is None:
             raise DistutilsError(
-                "%s is not a valid distutils Windows .exe" % dist_filename
+                "{0!s} is not a valid distutils Windows .exe".format(dist_filename)
             )
         # Create a dummy distribution object until we build the real distro
         dist = Distribution(None,
@@ -873,7 +871,7 @@ Please make the appropriate changes for your system and try again.
             f.write('Metadata-Version: 1.0\n')
             for k,v in cfg.items('metadata'):
                 if k<>'target_version':
-                    f.write('%s: %s\n' % (k.replace('_','-').title(), v))
+                    f.write('{0!s}: {1!s}\n'.format(k.replace('_','-').title(), v))
             f.close()
         script_dir = os.path.join(egg_info,'scripts')
         self.delete_blockers(   # delete entry-point scripts to avoid duping
@@ -985,16 +983,16 @@ Python's search path.  You MUST remove all of the relevant files and
 directories before you will be able to use the package(s) you are
 installing:
 
-   %s
+   {0!s}
 
-""" % '\n   '.join(blockers)
+""".format('\n   '.join(blockers))
 
         if self.ignore_conflicts_at_my_risk:
             msg += """\
-(Note: you can run EasyInstall on '%s' with the
+(Note: you can run EasyInstall on '{0!s}' with the
 --delete-conflicting option to attempt deletion of the above files
 and/or directories.)
-""" % dist.project_name
+""".format(dist.project_name)
         else:
             msg += """\
 Note: you can attempt this installation again with EasyInstall, and use
@@ -1042,15 +1040,15 @@ PYTHONPATH, or by being added to sys.path by your code.)
     def report_editable(self, spec, setup_script):
         dirname = os.path.dirname(setup_script)
         python = sys.executable
-        return """\nExtracted editable version of %(spec)s to %(dirname)s
+        return """\nExtracted editable version of {spec!s} to {dirname!s}
 
 If it uses setuptools in its setup script, you can activate it in
 "development" mode by going to that directory and running::
 
-    %(python)s setup.py develop
+    {python!s} setup.py develop
 
 See the setuptools documentation for the "develop" command for more info.
-""" % locals()
+""".format(**locals())
 
     def run_setup(self, setup_script, setup_base, args):
         sys.modules.setdefault('distutils.command.bdist_egg', bdist_egg)
@@ -1070,7 +1068,7 @@ See the setuptools documentation for the "develop" command for more info.
         try:
             run_setup(setup_script, args)
         except SystemExit, v:
-            raise DistutilsError("Setup script exited with %s" % (v.args[0],))
+            raise DistutilsError("Setup script exited with {0!s}".format(v.args[0]))
 
     def build_and_install(self, setup_script, setup_base):
         args = ['bdist_egg', '--dist-dir']
@@ -1186,11 +1184,11 @@ on PYTHONPATH and which Python does not read ".pth" files from.  The
 installation directory you specified (via --install-dir, --prefix, or
 the distutils default setting) was:
 
-    %s
+    {0!s}
 
 and your PYTHONPATH environment variable currently contains:
 
-    %r
+    {1!r}
 
 Here are some of your options for correcting the problem:
 
@@ -1206,7 +1204,7 @@ Here are some of your options for correcting the problem:
 
   http://packages.python.org/distribute/easy_install.html#custom-installation-locations
 
-Please make the appropriate changes for your system and try again.""" % (
+Please make the appropriate changes for your system and try again.""".format(
         self.install_dir, os.environ.get('PYTHONPATH','')
     )
 
@@ -1265,7 +1263,7 @@ Please make the appropriate changes for your system and try again.""" % (
         home = convert_path(os.path.expanduser("~"))
         for name, path in self.config_vars.iteritems():
             if path.startswith(home) and not os.path.isdir(path):
-                self.debug_print("os.makedirs('%s', 0700)" % path)
+                self.debug_print("os.makedirs('{0!s}', 0700)".format(path))
                 os.makedirs(path, 0700)
 
 
@@ -1468,7 +1466,7 @@ def get_exe_prefixes(exe_filename):
                 for pth in yield_lines(z.read(name)):
                     pth = pth.strip().replace('\\','/')
                     if not pth.startswith('import'):
-                        prefixes.append((('%s/%s/' % (parts[0],pth)), ''))
+                        prefixes.append((('{0!s}/{1!s}/'.format(parts[0], pth)), ''))
     finally:
         z.close()
     prefixes = [(x.lower(),y) for x, y in prefixes]
@@ -1481,7 +1479,7 @@ def parse_requirement_arg(spec):
         return Requirement.parse(spec)
     except ValueError:
         raise DistutilsError(
-            "Not a URL, existing file, or requirement spec: %r" % (spec,)
+            "Not a URL, existing file, or requirement spec: {0!r}".format(spec)
         )
 
 class PthDistributions(Environment):
@@ -1605,7 +1603,7 @@ def get_script_header(script_text, executable=sys_executable, wininst=False):
         executable = "python.exe"
     else:
         executable = nt_quote_arg(executable)
-    hdr = "#!%(executable)s%(options)s\n" % locals()
+    hdr = "#!{executable!s}{options!s}\n".format(**locals())
     if not isascii(hdr):
         # Non-ascii path to sys.executable, use -x to prevent warnings
         if options:
@@ -1615,7 +1613,7 @@ def get_script_header(script_text, executable=sys_executable, wininst=False):
         else:
             options = ' -x'
     executable = fix_jython_executable(executable, options)
-    hdr = "#!%(executable)s%(options)s\n" % locals()
+    hdr = "#!{executable!s}{options!s}\n".format(**locals())
     return hdr
 
 def auto_chmod(func, arg, exc):
@@ -1623,7 +1621,7 @@ def auto_chmod(func, arg, exc):
         chmod(arg, stat.S_IWRITE)
         return func(arg)
     exc = sys.exc_info()
-    raise exc[0], (exc[1][0], exc[1][1] + (" %s %s" % (func,arg)))
+    raise exc[0], (exc[1][0], exc[1][1] + (" {0!s} {1!s}".format(func, arg)))
 
 def uncache_zipdir(path):
     """Ensure that the importer caches dont have stale info for `path`"""
@@ -1737,7 +1735,7 @@ def fix_jython_executable(executable, options):
                      "         see http://bugs.jython.org/issue1112 for"
                              " more information.")
         else:
-            return '/usr/bin/env %s' % executable
+            return '/usr/bin/env {0!s}'.format(executable)
     return executable
 
 

--- a/jython-installer/src/main/resources/Lib/site-packages/distribute-0.6.19-py2.5.egg/setuptools/command/egg_info.py
+++ b/jython-installer/src/main/resources/Lib/site-packages/distribute-0.6.19-py2.5.egg/setuptools/command/egg_info.py
@@ -87,12 +87,11 @@ class egg_info(Command):
 
         try:
             list(
-                parse_requirements('%s==%s' % (self.egg_name,self.egg_version))
+                parse_requirements('{0!s}=={1!s}'.format(self.egg_name, self.egg_version))
             )
         except ValueError:
             raise DistutilsOptionError(
-                "Invalid distribution name or version syntax: %s-%s" %
-                (self.egg_name,self.egg_version)
+                "Invalid distribution name or version syntax: {0!s}-{1!s}".format(self.egg_name, self.egg_version)
             )
 
         if self.egg_base is None:
@@ -184,7 +183,7 @@ class egg_info(Command):
             version+=self.tag_build
         if self.tag_svn_revision and (
             os.path.exists('.svn') or os.path.exists('PKG-INFO')
-        ):  version += '-r%s' % self.get_svn_revision()
+        ):  version += '-r{0!s}'.format(self.get_svn_revision())
         if self.tag_date:
             import time; version += time.strftime("-%Y%m%d")
         return version
@@ -322,7 +321,7 @@ class manifest_maker(sdist):
         if os.sep!='/':
             files = [f.replace(os.sep,'/') for f in files]
         self.execute(write_file, (self.manifest, files),
-                     "writing manifest file '%s'" % self.manifest)
+                     "writing manifest file '{0!s}'".format(self.manifest))
 
     def warn(self, msg):    # suppress missing-file warnings from sdist
         if not msg.startswith("standard file not found:"):
@@ -400,7 +399,7 @@ def write_requirements(cmd, basename, filename):
     dist = cmd.distribution
     data = ['\n'.join(yield_lines(dist.install_requires or ()))]
     for extra,reqs in (dist.extras_require or {}).items():
-        data.append('\n\n[%s]\n%s' % (extra, '\n'.join(yield_lines(reqs))))
+        data.append('\n\n[{0!s}]\n{1!s}'.format(extra, '\n'.join(yield_lines(reqs))))
     cmd.write_or_delete_file("requirements", filename, ''.join(data))
 
 def write_toplevel_names(cmd, basename, filename):
@@ -434,7 +433,7 @@ def write_entries(cmd, basename, filename):
             if not isinstance(contents,basestring):
                 contents = EntryPoint.parse_group(section, contents)
                 contents = '\n'.join(map(str,contents.values()))
-            data.append('[%s]\n%s\n\n' % (section,contents))
+            data.append('[{0!s}]\n{1!s}\n\n'.format(section, contents))
         data = ''.join(data)
 
     cmd.write_or_delete_file('entry points', filename, data, True)

--- a/jython-installer/src/main/resources/Lib/site-packages/distribute-0.6.19-py2.5.egg/setuptools/command/install_egg_info.py
+++ b/jython-installer/src/main/resources/Lib/site-packages/distribute-0.6.19-py2.5.egg/setuptools/command/install_egg_info.py
@@ -35,7 +35,7 @@ class install_egg_info(Command):
         if not self.dry_run:
             pkg_resources.ensure_directory(self.target)
         self.execute(self.copytree, (),
-            "Copying %s to %s" % (self.source, self.target)
+            "Copying {0!s} to {1!s}".format(self.source, self.target)
         )
         self.install_namespaces()
 
@@ -93,8 +93,7 @@ class install_egg_info(Command):
                 trailer = '\n'
                 if '.' in pkg:
                     trailer = (
-                        "; m and setattr(sys.modules[%r], %r, m)\n"
-                        % ('.'.join(pth[:-1]), pth[-1])
+                        "; m and setattr(sys.modules[{0!r}], {1!r}, m)\n".format('.'.join(pth[:-1]), pth[-1])
                     )
                 f.write(
                     "import sys,types,os; "

--- a/jython-installer/src/main/resources/Lib/site-packages/distribute-0.6.19-py2.5.egg/setuptools/command/sdist.py
+++ b/jython-installer/src/main/resources/Lib/site-packages/distribute-0.6.19-py2.5.egg/setuptools/command/sdist.py
@@ -174,7 +174,7 @@ class sdist(_sdist):
                 if os.path.exists(fn):
                     self.filelist.append(fn)
                 else:
-                    self.warn("standard file '%s' not found" % fn)
+                    self.warn("standard file '{0!s}' not found".format(fn))
 
         optional = ['test/test*.py', 'setup.cfg']
         for pattern in optional:

--- a/jython-installer/src/main/resources/Lib/site-packages/distribute-0.6.19-py2.5.egg/setuptools/command/setopt.py
+++ b/jython-installer/src/main/resources/Lib/site-packages/distribute-0.6.19-py2.5.egg/setuptools/command/setopt.py
@@ -20,7 +20,7 @@ def config_file(kind="local"):
         )
     if kind=='user':
         dot = os.name=='posix' and '.' or ''
-        return os.path.expanduser(convert_path("~/%spydistutils.cfg" % dot))
+        return os.path.expanduser(convert_path("~/{0!s}pydistutils.cfg".format(dot)))
     raise ValueError(
         "config_file() type must be 'local', 'global', or 'user'", kind
     )

--- a/jython-installer/src/main/resources/Lib/site-packages/distribute-0.6.19-py2.5.egg/setuptools/command/test.py
+++ b/jython-installer/src/main/resources/Lib/site-packages/distribute-0.6.19-py2.5.egg/setuptools/command/test.py
@@ -113,7 +113,7 @@ class test(Command):
             sys.path.insert(0, normalize_path(ei_cmd.egg_base))
             working_set.__init__()
             add_activation_listener(lambda dist: dist.activate())
-            require('%s==%s' % (ei_cmd.egg_name, ei_cmd.egg_version))
+            require('{0!s}=={1!s}'.format(ei_cmd.egg_name, ei_cmd.egg_version))
             func()
         finally:
             sys.path[:] = old_path
@@ -131,9 +131,9 @@ class test(Command):
         if self.test_suite:
             cmd = ' '.join(self.test_args)
             if self.dry_run:
-                self.announce('skipping "unittest %s" (dry run)' % cmd)
+                self.announce('skipping "unittest {0!s}" (dry run)'.format(cmd))
             else:
-                self.announce('running "unittest %s"' % cmd)
+                self.announce('running "unittest {0!s}"'.format(cmd))
                 self.with_project_on_sys_path(self.run_tests)
 
 

--- a/jython-installer/src/main/resources/Lib/site-packages/distribute-0.6.19-py2.5.egg/setuptools/command/upload.py
+++ b/jython-installer/src/main/resources/Lib/site-packages/distribute-0.6.19-py2.5.egg/setuptools/command/upload.py
@@ -27,7 +27,7 @@ class upload(Command):
 
     user_options = [
         ('repository=', 'r',
-         "url of repository [default: %s]" % DEFAULT_REPOSITORY),
+         "url of repository [default: {0!s}]".format(DEFAULT_REPOSITORY)),
         ('show-response', None,
          'display full response text from server'),
         ('sign', 's',
@@ -52,7 +52,7 @@ class upload(Command):
         if os.environ.has_key('HOME'):
             rc = os.path.join(os.environ['HOME'], '.pypirc')
             if os.path.exists(rc):
-                self.announce('Using PyPI login from %s' % rc)
+                self.announce('Using PyPI login from {0!s}'.format(rc))
                 config = ConfigParser.ConfigParser({
                         'username':'',
                         'password':'',
@@ -89,7 +89,7 @@ class upload(Command):
         basename = os.path.basename(filename)
         comment = ''
         if command=='bdist_egg' and self.distribution.has_ext_modules():
-            comment = "built on %s" % platform.platform(terse=1)
+            comment = "built on {0!s}".format(platform.platform(terse=1))
         data = {
             ':action':'file_upload',
             'protcol_version':'1',
@@ -103,9 +103,9 @@ class upload(Command):
         if command == 'bdist_rpm':
             dist, version, id = platform.dist()
             if dist:
-                comment = 'built for %s %s' % (dist, version)
+                comment = 'built for {0!s} {1!s}'.format(dist, version)
         elif command == 'bdist_dumb':
-            comment = 'built for %s' % platform.platform(terse=1)
+            comment = 'built for {0!s}'.format(platform.platform(terse=1))
         data['comment'] = comment
 
         if self.sign:
@@ -126,13 +126,13 @@ class upload(Command):
                 value = [value]
             for value in value:
                 if type(value) is tuple:
-                    fn = ';filename="%s"' % value[0]
+                    fn = ';filename="{0!s}"'.format(value[0])
                     value = value[1]
                 else:
                     fn = ""
                 value = str(value)
                 body.write(sep_boundary)
-                body.write('\nContent-Disposition: form-data; name="%s"'%key)
+                body.write('\nContent-Disposition: form-data; name="{0!s}"'.format(key))
                 body.write(fn)
                 body.write("\n\n")
                 body.write(value)
@@ -142,7 +142,7 @@ class upload(Command):
         body.write("\n")
         body = body.getvalue()
 
-        self.announce("Submitting %s to %s" % (filename, self.repository), log.INFO)
+        self.announce("Submitting {0!s} to {1!s}".format(filename, self.repository), log.INFO)
 
         # build the Request
         # We can't use urllib2 since we need to send the Basic
@@ -163,7 +163,7 @@ class upload(Command):
             http.connect()
             http.putrequest("POST", url)
             http.putheader('Content-type',
-                           'multipart/form-data; boundary=%s'%boundary)
+                           'multipart/form-data; boundary={0!s}'.format(boundary))
             http.putheader('Content-length', str(len(body)))
             http.putheader('Authorization', auth)
             http.endheaders()
@@ -174,10 +174,10 @@ class upload(Command):
 
         r = http.getresponse()
         if r.status == 200:
-            self.announce('Server response (%s): %s' % (r.status, r.reason),
+            self.announce('Server response ({0!s}): {1!s}'.format(r.status, r.reason),
                           log.INFO)
         else:
-            self.announce('Upload failed (%s): %s' % (r.status, r.reason),
+            self.announce('Upload failed ({0!s}): {1!s}'.format(r.status, r.reason),
                           log.ERROR)
         if self.show_response:
             print '-'*75, r.read(), '-'*75

--- a/jython-installer/src/main/resources/Lib/site-packages/distribute-0.6.19-py2.5.egg/setuptools/command/upload_docs.py
+++ b/jython-installer/src/main/resources/Lib/site-packages/distribute-0.6.19-py2.5.egg/setuptools/command/upload_docs.py
@@ -44,7 +44,7 @@ class upload_docs(upload):
 
     user_options = [
         ('repository=', 'r',
-         "url of repository [default: %s]" % upload.DEFAULT_REPOSITORY),
+         "url of repository [default: {0!s}]".format(upload.DEFAULT_REPOSITORY)),
         ('show-response', None,
          'display full response text from server'),
         ('upload-dir=', None, 'directory to upload'),
@@ -62,18 +62,17 @@ class upload_docs(upload):
             self.upload_dir = os.path.join(build.build_base, 'docs')
             self.mkpath(self.upload_dir)
         self.ensure_dirname('upload_dir')
-        self.announce('Using upload directory %s' % self.upload_dir)
+        self.announce('Using upload directory {0!s}'.format(self.upload_dir))
 
     def create_zipfile(self):
         name = self.distribution.metadata.get_name()
         tmp_dir = tempfile.mkdtemp()
-        tmp_file = os.path.join(tmp_dir, "%s.zip" % name)
+        tmp_file = os.path.join(tmp_dir, "{0!s}.zip".format(name))
         zip_file = zipfile.ZipFile(tmp_file, "w")
         for root, dirs, files in os.walk(self.upload_dir):
             if root == self.upload_dir and not files:
                 raise DistutilsOptionError(
-                    "no files found in upload directory '%s'"
-                    % self.upload_dir)
+                    "no files found in upload directory '{0!s}'".format(self.upload_dir))
             for name in files:
                 full = os.path.join(root, name)
                 relative = root[len(self.upload_dir):].lstrip(os.path.sep)
@@ -115,12 +114,12 @@ class upload_docs(upload):
                 values = [values]
             for value in values:
                 if type(value) is tuple:
-                    fn = b(';filename="%s"' % value[0])
+                    fn = b(';filename="{0!s}"'.format(value[0]))
                     value = value[1]
                 else:
                     fn = b("")
                 body.append(sep_boundary)
-                body.append(b('\nContent-Disposition: form-data; name="%s"'%key))
+                body.append(b('\nContent-Disposition: form-data; name="{0!s}"'.format(key)))
                 body.append(fn)
                 body.append(b("\n\n"))
                 body.append(b(value))
@@ -130,7 +129,7 @@ class upload_docs(upload):
         body.append(b("\n"))
         body = b('').join(body)
 
-        self.announce("Submitting documentation to %s" % (self.repository),
+        self.announce("Submitting documentation to {0!s}".format((self.repository)),
                       log.INFO)
 
         # build the Request
@@ -152,7 +151,7 @@ class upload_docs(upload):
             conn.connect()
             conn.putrequest("POST", url)
             conn.putheader('Content-type',
-                           'multipart/form-data; boundary=%s'%boundary)
+                           'multipart/form-data; boundary={0!s}'.format(boundary))
             conn.putheader('Content-length', str(len(body)))
             conn.putheader('Authorization', auth)
             conn.endheaders()
@@ -163,16 +162,16 @@ class upload_docs(upload):
 
         r = conn.getresponse()
         if r.status == 200:
-            self.announce('Server response (%s): %s' % (r.status, r.reason),
+            self.announce('Server response ({0!s}): {1!s}'.format(r.status, r.reason),
                           log.INFO)
         elif r.status == 301:
             location = r.getheader('Location')
             if location is None:
-                location = 'http://packages.python.org/%s/' % meta.get_name()
-            self.announce('Upload successful. Visit %s' % location,
+                location = 'http://packages.python.org/{0!s}/'.format(meta.get_name())
+            self.announce('Upload successful. Visit {0!s}'.format(location),
                           log.INFO)
         else:
-            self.announce('Upload failed (%s): %s' % (r.status, r.reason),
+            self.announce('Upload failed ({0!s}): {1!s}'.format(r.status, r.reason),
                           log.ERROR)
         if self.show_response:
             print '-'*75, r.read(), '-'*75

--- a/jython-installer/src/main/resources/Lib/site-packages/distribute-0.6.19-py2.5.egg/setuptools/depends.py
+++ b/jython-installer/src/main/resources/Lib/site-packages/distribute-0.6.19-py2.5.egg/setuptools/depends.py
@@ -29,7 +29,7 @@ class Require:
     def full_name(self):
         """Return full package/distribution name, w/version"""
         if self.requested_version is not None:
-            return '%s-%s' % (self.name,self.requested_version)
+            return '{0!s}-{1!s}'.format(self.name, self.requested_version)
         return self.name
 
 
@@ -135,7 +135,7 @@ def find_module(module, paths=None):
             paths = [path]
 
         elif parts:
-            raise ImportError("Can't find %r in %s" % (parts,module))
+            raise ImportError("Can't find {0!r} in {1!s}".format(parts, module))
 
     return info
 

--- a/jython-installer/src/main/resources/Lib/site-packages/distribute-0.6.19-py2.5.egg/setuptools/dist.py
+++ b/jython-installer/src/main/resources/Lib/site-packages/distribute-0.6.19-py2.5.egg/setuptools/dist.py
@@ -21,7 +21,7 @@ def _get_unpatched(cls):
         cls, = cls.__bases__
     if not cls.__module__.startswith('distutils'):
         raise AssertionError(
-            "distutils has already been patched by %r" % cls
+            "distutils has already been patched by {0!r}".format(cls)
         )
     return cls
 
@@ -35,8 +35,7 @@ def check_importable(dist, attr, value):
         assert not ep.extras
     except (TypeError,ValueError,AttributeError,AssertionError):
         raise DistutilsSetupError(
-            "%r must be importable 'module:attrs' string (got %r)"
-            % (attr,value)
+            "{0!r} must be importable 'module:attrs' string (got {1!r})".format(attr, value)
         )
 
 
@@ -46,7 +45,7 @@ def assert_string_list(dist, attr, value):
         assert ''.join(value)!=value
     except (TypeError,ValueError,AttributeError,AssertionError):
         raise DistutilsSetupError(
-            "%r must be a list of strings (got %r)" % (attr,value)
+            "{0!r} must be a list of strings (got {1!r})".format(attr, value)
         )
 
 def check_nsp(dist, attr, value):
@@ -56,7 +55,7 @@ def check_nsp(dist, attr, value):
         if not dist.has_contents_for(nsp):
             raise DistutilsSetupError(
                 "Distribution contains no modules or packages for " +
-                "namespace package %r" % nsp
+                "namespace package {0!r}".format(nsp)
             )
         if '.' in nsp:
             parent = '.'.join(nsp.split('.')[:-1])
@@ -85,7 +84,7 @@ def assert_bool(dist, attr, value):
     """Verify that value is True, False, 0, or 1"""
     if bool(value) != value:
         raise DistutilsSetupError(
-            "%r must be a boolean value (got %r)" % (attr,value)
+            "{0!r} must be a boolean value (got {1!r})".format(attr, value)
         )
 def check_requirements(dist, attr, value):
     """Verify that install_requires is a valid requirements list"""
@@ -461,13 +460,13 @@ class Distribution(_Distribution):
         """Handle 'exclude()' for list/tuple attrs without a special handler"""
         if not isinstance(value,sequence):
             raise DistutilsSetupError(
-                "%s: setting must be a list or tuple (%r)" % (name, value)
+                "{0!s}: setting must be a list or tuple ({1!r})".format(name, value)
             )
         try:
             old = getattr(self,name)
         except AttributeError:
             raise DistutilsSetupError(
-                "%s: No such distribution setting" % name
+                "{0!s}: No such distribution setting".format(name)
             )
         if old is not None and not isinstance(old,sequence):
             raise DistutilsSetupError(
@@ -481,13 +480,13 @@ class Distribution(_Distribution):
 
         if not isinstance(value,sequence):
             raise DistutilsSetupError(
-                "%s: setting must be a list (%r)" % (name, value)
+                "{0!s}: setting must be a list ({1!r})".format(name, value)
             )
         try:
             old = getattr(self,name)
         except AttributeError:
             raise DistutilsSetupError(
-                "%s: No such distribution setting" % name
+                "{0!s}: No such distribution setting".format(name)
             )
         if old is None:
             setattr(self,name,value)
@@ -524,7 +523,7 @@ class Distribution(_Distribution):
     def _exclude_packages(self,packages):
         if not isinstance(packages,sequence):
             raise DistutilsSetupError(
-                "packages: setting must be a list or tuple (%r)" % (packages,)
+                "packages: setting must be a list or tuple ({0!r})".format(packages)
             )
         map(self.exclude_package, packages)
 

--- a/jython-installer/src/main/resources/Lib/site-packages/distribute-0.6.19-py2.5.egg/setuptools/package_index.py
+++ b/jython-installer/src/main/resources/Lib/site-packages/distribute-0.6.19-py2.5.egg/setuptools/package_index.py
@@ -153,7 +153,7 @@ def find_external_links(url, page):
             if match:
                 yield urlparse.urljoin(url, htmldecode(match.group(1)))
 
-user_agent = "Python-urllib/%s distribute/%s" % (
+user_agent = "Python-urllib/{0!s} distribute/{1!s}".format(
     sys.version[:3], require('distribute')[0].version
 )
 
@@ -294,13 +294,13 @@ class PackageIndex(Environment):
                 base, frag = egg_info_for_url(new_url)
                 if base.endswith('.py') and not frag:
                     if ver:
-                        new_url+='#egg=%s-%s' % (pkg,ver)
+                        new_url+='#egg={0!s}-{1!s}'.format(pkg, ver)
                     else:
                         self.need_version_info(url)
                 self.scan_url(new_url)
 
             return PYPI_MD5.sub(
-                lambda m: '<a href="%s#md5=%s">%s</a>' % m.group(1,3,2), page
+                lambda m: '<a href="{0!s}#md5={1!s}">{2!s}</a>'.format(*m.group(1,3,2)), page
             )
         else:
             return ""   # no sense double-scanning non-package pages
@@ -424,8 +424,7 @@ class PackageIndex(Environment):
                     spec = Requirement.parse(spec)
                 except ValueError:
                     raise DistutilsError(
-                        "Not a URL, existing file, or requirement spec: %r" %
-                        (spec,)
+                        "Not a URL, existing file, or requirement spec: {0!r}".format(spec)
                     )
         return getattr(self.fetch_distribution(spec, tmpdir),'location',None)
 
@@ -571,7 +570,7 @@ class PackageIndex(Environment):
             fp = self.open_url(url)
             if isinstance(fp, urllib2.HTTPError):
                 raise DistutilsError(
-                    "Can't download %s: %s %s" % (url, fp.code,fp.msg)
+                    "Can't download {0!s}: {1!s} {2!s}".format(url, fp.code, fp.msg)
                 )
             cs = md5()
             headers = fp.info()
@@ -613,15 +612,14 @@ class PackageIndex(Environment):
             if warning:
                 self.warn(warning, msg)
             else:
-                raise DistutilsError('%s %s' % (url, msg))
+                raise DistutilsError('{0!s} {1!s}'.format(url, msg))
         except urllib2.HTTPError, v:
             return v
         except urllib2.URLError, v:
             if warning:
                 self.warn(warning, v.reason)
             else:
-                raise DistutilsError("Download error for %s: %s"
-                                     % (url, v.reason))
+                raise DistutilsError("Download error for {0!s}: {1!s}".format(url, v.reason))
         except httplib.BadStatusLine, v:
             if warning:
                 self.warn(warning, v.line)
@@ -633,8 +631,7 @@ class PackageIndex(Environment):
             if warning:
                 self.warn(warning, v)
             else:
-                raise DistutilsError("Download error for %s: %s"
-                                     % (url, v))
+                raise DistutilsError("Download error for {0!s}: {1!s}".format(url, v))
 
     def _download_url(self, scheme, url, tmpdir):
         # Determine download filename
@@ -693,7 +690,7 @@ class PackageIndex(Environment):
     def _download_svn(self, url, filename):
         url = url.split('#',1)[0]   # remove any fragment for svn's sake
         self.info("Doing subversion checkout from %s to %s", url, filename)
-        os.system("svn checkout -q %s %s" % (url, filename))
+        os.system("svn checkout -q {0!s} {1!s}".format(url, filename))
         return filename
 
     def debug(self, msg, *args):
@@ -819,10 +816,10 @@ def local_open(url):
                 break
             elif os.path.isdir(os.path.join(filename,f)):
                 f+='/'
-            files.append("<a href=%r>%s</a>" % (f,f))
+            files.append("<a href={0!r}>{1!s}</a>".format(f, f))
         else:
-            body = ("<html><head><title>%s</title>" % url) + \
-                "</head><body>%s</body></html>" % '\n'.join(files)
+            body = ("<html><head><title>{0!s}</title>".format(url)) + \
+                "</head><body>{0!s}</body></html>".format('\n'.join(files))
         status, message = 200, "OK"
     else:
         status, message, body = 404, "Path not found", "Not found"

--- a/jython-installer/src/main/resources/Lib/site-packages/distribute-0.6.19-py2.5.egg/setuptools/sandbox.py
+++ b/jython-installer/src/main/resources/Lib/site-packages/distribute-0.6.19-py2.5.egg/setuptools/sandbox.py
@@ -245,7 +245,7 @@ class SandboxViolation(DistutilsError):
     """A setup script attempted to modify the filesystem outside the sandbox"""
 
     def __str__(self):
-        return """SandboxViolation: %s%r %s
+        return """SandboxViolation: {0!s}{1!r} {2!s}
 
 The package setup script has attempted to modify files on your system
 that are not within the EasyInstall build area, and has been aborted.
@@ -253,7 +253,7 @@ that are not within the EasyInstall build area, and has been aborted.
 This package cannot be safely installed by EasyInstall, and may not
 support alternate installation locations even if you run its setup
 script by hand.  Please inform the package's author and the EasyInstall
-maintainers to find out if a fix or workaround is available.""" % self.args
+maintainers to find out if a fix or workaround is available.""".format(*self.args)
 
 
 

--- a/jython-installer/src/main/resources/Lib/site-packages/distribute-0.6.19-py2.5.egg/setuptools/tests/doctest.py
+++ b/jython-installer/src/main/resources/Lib/site-packages/distribute-0.6.19-py2.5.egg/setuptools/tests/doctest.py
@@ -367,7 +367,7 @@ class _OutputRedirectingPdb(pdb.Pdb):
 # [XX] Normalize with respect to os.path.pardir?
 def _module_relative_path(module, path):
     if not inspect.ismodule(module):
-        raise TypeError, 'Expected a module: %r' % module
+        raise TypeError, 'Expected a module: {0!r}'.format(module)
     if path.startswith('/'):
         raise ValueError, 'Module-relative files may not have absolute paths'
 
@@ -498,9 +498,8 @@ class DocTest:
         elif len(self.examples) == 1:
             examples = '1 example'
         else:
-            examples = '%d examples' % len(self.examples)
-        return ('<DocTest %s from %s:%s (%s)>' %
-                (self.name, self.filename, self.lineno, examples))
+            examples = '{0:d} examples'.format(len(self.examples))
+        return ('<DocTest {0!s} from {1!s}:{2!s} ({3!s})>'.format(self.name, self.filename, self.lineno, examples))
 
 
     # This lets us sort tests by name:
@@ -895,7 +894,7 @@ class DocTestFinder:
         add them to `tests`.
         """
         if self._verbose:
-            print 'Finding tests in %s' % name
+            print 'Finding tests in {0!s}'.format(name)
 
         # If we've already processed this object, then ignore it.
         if id(obj) in seen:
@@ -913,7 +912,7 @@ class DocTestFinder:
                 # Check if this contained object should be ignored.
                 if self._filter(val, name, valname):
                     continue
-                valname = '%s.%s' % (name, valname)
+                valname = '{0!s}.{1!s}'.format(name, valname)
                 # Recurse to functions & classes.
                 if ((inspect.isfunction(val) or inspect.isclass(val)) and
                     self._from_module(module, val)):
@@ -934,7 +933,7 @@ class DocTestFinder:
                                      "must be strings, functions, methods, "
                                      "classes, or modules: %r" %
                                      (type(val),))
-                valname = '%s.__test__.%s' % (name, valname)
+                valname = '{0!s}.__test__.{1!s}'.format(name, valname)
                 self._find(tests, val, valname, module, source_lines,
                            globs, seen)
 
@@ -954,7 +953,7 @@ class DocTestFinder:
                 if ((inspect.isfunction(val) or inspect.isclass(val) or
                       isinstance(val, property)) and
                       self._from_module(module, val)):
-                    valname = '%s.%s' % (name, valname)
+                    valname = '{0!s}.{1!s}'.format(name, valname)
                     self._find(tests, val, valname, module, source_lines,
                                globs, seen)
 
@@ -1012,8 +1011,8 @@ class DocTestFinder:
         if inspect.isclass(obj):
             if source_lines is None:
                 return None
-            pat = re.compile(r'^\s*class\s*%s\b' %
-                             getattr(obj, '__name__', '-'))
+            pat = re.compile(r'^\s*class\s*{0!s}\b'.format(
+                             getattr(obj, '__name__', '-')))
             for i, line in enumerate(source_lines):
                 if pat.match(line):
                     lineno = i
@@ -1184,10 +1183,9 @@ class DocTestRunner:
                 lineno = test.lineno + example.lineno + 1
             else:
                 lineno = '?'
-            out.append('File "%s", line %s, in %s' %
-                       (test.filename, lineno, test.name))
+            out.append('File "{0!s}", line {1!s}, in {2!s}'.format(test.filename, lineno, test.name))
         else:
-            out.append('Line %s, in %s' % (example.lineno+1, test.name))
+            out.append('Line {0!s}, in {1!s}'.format(example.lineno+1, test.name))
         out.append('Failed example:')
         source = example.source
         out.append(_indent(source))
@@ -1243,7 +1241,7 @@ class DocTestRunner:
             # Use a special filename for compile(), so we can retrieve
             # the source code during interactive debugging (see
             # __patched_linecache_getlines).
-            filename = '<doctest %s[%d]>' % (test.name, examplenum)
+            filename = '<doctest {0!s}[{1:d}]>'.format(test.name, examplenum)
 
             # Run the example in the given context (globs), and record
             # any exception that gets raised.  (But don't intercept
@@ -1435,13 +1433,13 @@ class DocTestRunner:
                 print len(passed), "items passed all tests:"
                 passed.sort()
                 for thing, count in passed:
-                    print " %3d tests in %s" % (count, thing)
+                    print " {0:3d} tests in {1!s}".format(count, thing)
         if failed:
             print self.DIVIDER
             print len(failed), "items had failures:"
             failed.sort()
             for thing, (f, t) in failed:
-                print " %3d of %3d in %s" % (f, t, thing)
+                print " {0:3d} of {1:3d} in {2!s}".format(f, t, thing)
         if verbose:
             print totalt, "tests in", len(self._name2ft), "items."
             print totalt - totalf, "passed and", totalf, "failed."
@@ -1500,7 +1498,7 @@ class OutputChecker:
         # blank line, unless the DONT_ACCEPT_BLANKLINE flag is used.
         if not (optionflags & DONT_ACCEPT_BLANKLINE):
             # Replace <BLANKLINE> in want with a blank line.
-            want = re.sub('(?m)^%s\s*?$' % re.escape(BLANKLINE_MARKER),
+            want = re.sub('(?m)^{0!s}\s*?$'.format(re.escape(BLANKLINE_MARKER)),
                           '', want)
             # If a line in got contains only spaces, then remove the
             # spaces.
@@ -1585,16 +1583,16 @@ class OutputChecker:
                 assert 0, 'Bad diff option'
             # Remove trailing whitespace on diff output.
             diff = [line.rstrip() + '\n' for line in diff]
-            return 'Differences (%s):\n' % kind + _indent(''.join(diff))
+            return 'Differences ({0!s}):\n'.format(kind) + _indent(''.join(diff))
 
         # If we're not using diff, then simply list the expected
         # output followed by the actual output.
         if want and got:
-            return 'Expected:\n%sGot:\n%s' % (_indent(want), _indent(got))
+            return 'Expected:\n{0!s}Got:\n{1!s}'.format(_indent(want), _indent(got))
         elif want:
-            return 'Expected:\n%sGot nothing\n' % _indent(want)
+            return 'Expected:\n{0!s}Got nothing\n'.format(_indent(want))
         elif got:
-            return 'Expected nothing\nGot:\n%s' % _indent(got)
+            return 'Expected nothing\nGot:\n{0!s}'.format(_indent(got))
         else:
             return 'Expected nothing\nGot nothing\n'
 
@@ -1837,7 +1835,7 @@ def testmod(m=None, name=None, globs=None, verbose=None, isprivate=None,
 
     # Check that we were actually given a module.
     if not inspect.ismodule(m):
-        raise TypeError("testmod: module required; %r" % (m,))
+        raise TypeError("testmod: module required; {0!r}".format(m))
 
     # If no name was given, then use the module's name.
     if name is None:
@@ -2021,8 +2019,7 @@ class Tester:
         if mod is None and globs is None:
             raise TypeError("Tester.__init__: must specify mod or globs")
         if mod is not None and not inspect.ismodule(mod):
-            raise TypeError("Tester.__init__: mod must be a module; %r" %
-                            (mod,))
+            raise TypeError("Tester.__init__: mod must be a module; {0!r}".format(mod))
         if globs is None:
             globs = mod.__dict__
         self.globs = globs
@@ -2169,7 +2166,7 @@ class DocTestCase(unittest.TestCase):
         if test.lineno is None:
             lineno = 'unknown line number'
         else:
-            lineno = '%s' % test.lineno
+            lineno = '{0!s}'.format(test.lineno)
         lname = '.'.join(test.name.split('.')[-1:])
         return ('Failed doctest test for %s\n'
                 '  File "%s", line %s, in %s\n\n%s'
@@ -2253,7 +2250,7 @@ class DocTestCase(unittest.TestCase):
 
     def __repr__(self):
         name = self._dt_test.name.split('.')
-        return "%s (%s)" % (name[-1], '.'.join(name[:-1]))
+        return "{0!s} ({1!s})".format(name[-1], '.'.join(name[:-1]))
 
     __str__ = __repr__
 
@@ -2333,8 +2330,7 @@ class DocFileCase(DocTestCase):
     __str__ = __repr__
 
     def format_failure(self, err):
-        return ('Failed doctest test for %s\n  File "%s", line 0\n\n%s'
-                % (self._dt_test.name, self._dt_test.filename, err)
+        return ('Failed doctest test for {0!s}\n  File "{1!s}", line 0\n\n{2!s}'.format(self._dt_test.name, self._dt_test.filename, err)
                 )
 
 def DocFileTest(path, module_relative=True, package=None,
@@ -2557,7 +2553,7 @@ def debug_script(src, pm=False, globs=None):
         else:
             # Note that %r is vital here.  '%s' instead can, e.g., cause
             # backslashes to get treated as metacharacters on Windows.
-            pdb.run("execfile(%r)" % srcfilename, globs, globs)
+            pdb.run("execfile({0!r})".format(srcfilename), globs, globs)
 
     finally:
         os.remove(srcfilename)

--- a/jython-installer/src/main/resources/Lib/site-packages/distribute-0.6.19-py2.5.egg/setuptools/tests/server.py
+++ b/jython-installer/src/main/resources/Lib/site-packages/distribute-0.6.19-py2.5.egg/setuptools/tests/server.py
@@ -35,14 +35,14 @@ class IndexServer(HTTPServer):
         self._run = False
         try:
             if sys.version > '2.6':
-                urllib2.urlopen('http://127.0.0.1:%s/' % self.server_port,
+                urllib2.urlopen('http://127.0.0.1:{0!s}/'.format(self.server_port),
                                 None, 5)
             else:
-                urllib2.urlopen('http://127.0.0.1:%s/' % self.server_port)
+                urllib2.urlopen('http://127.0.0.1:{0!s}/'.format(self.server_port))
         except urllib2.URLError:
             pass
         self.thread.join()
 
     def base_url(self):
         port = self.server_port
-        return 'http://127.0.0.1:%s/setuptools/tests/indexes/' % port
+        return 'http://127.0.0.1:{0!s}/setuptools/tests/indexes/'.format(port)

--- a/jython-installer/src/main/resources/Lib/site-packages/distribute-0.6.19-py2.5.egg/setuptools/tests/test_easy_install.py
+++ b/jython-installer/src/main/resources/Lib/site-packages/distribute-0.6.19-py2.5.egg/setuptools/tests/test_easy_install.py
@@ -30,7 +30,7 @@ class FakeDist(object):
         return 'spec'
 
 WANTED = """\
-#!%s
+#!{0!s}
 # EASY-INSTALL-ENTRY-SCRIPT: 'spec','console_scripts','name'
 __requires__ = 'spec'
 import sys
@@ -40,7 +40,7 @@ if __name__ == '__main__':
     sys.exit(
         load_entry_point('spec', 'console_scripts', 'name')()
     )
-""" % sys.executable
+""".format(sys.executable)
 
 SETUP_PY = """\
 from setuptools import setup

--- a/jython-installer/src/main/resources/Lib/site-packages/distribute-0.6.19-py2.5.egg/setuptools/tests/test_resources.py
+++ b/jython-installer/src/main/resources/Lib/site-packages/distribute-0.6.19-py2.5.egg/setuptools/tests/test_resources.py
@@ -525,12 +525,12 @@ class ScriptHeaderTests(TestCase):
         if not sys.platform.startswith('java') or not is_sh(sys.executable):
             # This test is for non-Jython platforms
             self.assertEqual(get_script_header('#!/usr/local/bin/python'),
-                             '#!%s\n' % os.path.normpath(sys.executable))
+                             '#!{0!s}\n'.format(os.path.normpath(sys.executable)))
             self.assertEqual(get_script_header('#!/usr/bin/python -x'),
-                             '#!%s  -x\n' % os.path.normpath(sys.executable))
+                             '#!{0!s}  -x\n'.format(os.path.normpath(sys.executable)))
             self.assertEqual(get_script_header('#!/usr/bin/python',
                                                executable=self.non_ascii_exe),
-                             '#!%s -x\n' % self.non_ascii_exe)
+                             '#!{0!s} -x\n'.format(self.non_ascii_exe))
 
     def test_get_script_header_jython_workaround(self):
         # This test doesn't work with Python 3 in some locales
@@ -545,19 +545,19 @@ class ScriptHeaderTests(TestCase):
             exe = os.path.normpath(os.path.splitext(__file__)[0] + '.py')
             self.assertEqual(
                 get_script_header('#!/usr/local/bin/python', executable=exe),
-                '#!/usr/bin/env %s\n' % exe)
+                '#!/usr/bin/env {0!s}\n'.format(exe))
 
             # Ensure we generate what is basically a broken shebang line
             # when there's options, with a warning emitted
             sys.stdout = sys.stderr = StringIO.StringIO()
             self.assertEqual(get_script_header('#!/usr/bin/python -x',
                                                executable=exe),
-                             '#!%s  -x\n' % exe)
+                             '#!{0!s}  -x\n'.format(exe))
             self.assert_('Unable to adapt shebang line' in sys.stdout.getvalue())
             sys.stdout = sys.stderr = StringIO.StringIO()
             self.assertEqual(get_script_header('#!/usr/bin/python',
                                                executable=self.non_ascii_exe),
-                             '#!%s -x\n' % self.non_ascii_exe)
+                             '#!{0!s} -x\n'.format(self.non_ascii_exe))
             self.assert_('Unable to adapt shebang line' in sys.stdout.getvalue())
         finally:
             sys.platform = platform

--- a/jython-installer/src/main/resources/Lib/site-packages/pip/__init__.py
+++ b/jython-installer/src/main/resources/Lib/site-packages/pip/__init__.py
@@ -105,9 +105,9 @@ def main(initial_args=None):
         if close_commands:
             guess = close_commands[0]
             if args[1:]:
-                guess = "%s %s" % (guess, " ".join(args[1:]))
+                guess = "{0!s} {1!s}".format(guess, " ".join(args[1:]))
         else:
-            guess = 'install %s' % command
+            guess = 'install {0!s}'.format(command)
         error_dict = {'arg': command, 'guess': guess,
                       'script': os.path.basename(sys.argv[0])}
         parser.error('No command by the name %(script)s %(arg)s\n  '
@@ -145,7 +145,7 @@ class FrozenRequirement(object):
             editable = True
             req = get_src_requirement(dist, location, find_tags)
             if req is None:
-                logger.warn('Could not determine repository location of %s' % location)
+                logger.warn('Could not determine repository location of {0!s}'.format(location))
                 comments.append('## !! Could not determine repository location')
                 req = dist.as_requirement()
                 editable = False
@@ -164,16 +164,16 @@ class FrozenRequirement(object):
                         ).get_location(dist, dependency_links)
                 if not svn_location:
                     logger.warn(
-                        'Warning: cannot find svn location for %s' % req)
+                        'Warning: cannot find svn location for {0!s}'.format(req))
                     comments.append('## FIXME: could not find svn URL in dependency_links for this package:')
                 else:
-                    comments.append('# Installing as editable to satisfy requirement %s:' % req)
+                    comments.append('# Installing as editable to satisfy requirement {0!s}:'.format(req))
                     if ver_match:
                         rev = ver_match.group(1)
                     else:
-                        rev = '{%s}' % date_match.group(1)
+                        rev = '{{{0!s}}}'.format(date_match.group(1))
                     editable = True
-                    req = '%s@%s#egg=%s' % (svn_location, rev, cls.egg_name(dist))
+                    req = '{0!s}@{1!s}#egg={2!s}'.format(svn_location, rev, cls.egg_name(dist))
         return cls(dist.project_name, req, editable, comments)
 
     @staticmethod
@@ -187,7 +187,7 @@ class FrozenRequirement(object):
     def __str__(self):
         req = self.req
         if self.editable:
-            req = '-e %s' % req
+            req = '-e {0!s}'.format(req)
         return '\n'.join(list(self.comments)+[str(req)])+'\n'
 
 ############################################################
@@ -203,14 +203,14 @@ def call_subprocess(cmd, show_stdout=True,
         cmd_parts = []
         for part in cmd:
             if ' ' in part or '\n' in part or '"' in part or "'" in part:
-                part = '"%s"' % part.replace('"', '\\"')
+                part = '"{0!s}"'.format(part.replace('"', '\\"'))
             cmd_parts.append(part)
         command_desc = ' '.join(cmd_parts)
     if show_stdout:
         stdout = None
     else:
         stdout = subprocess.PIPE
-    logger.log(command_level, "Running command %s" % command_desc)
+    logger.log(command_level, "Running command {0!s}".format(command_desc))
     env = os.environ.copy()
     if extra_environ:
         env.update(extra_environ)
@@ -221,7 +221,7 @@ def call_subprocess(cmd, show_stdout=True,
     except Exception:
         e = sys.exc_info()[1]
         logger.fatal(
-            "Error %s while executing command %s" % (e, command_desc))
+            "Error {0!s} while executing command {1!s}".format(e, command_desc))
         raise
     all_output = []
     if stdout is not None:
@@ -248,15 +248,13 @@ def call_subprocess(cmd, show_stdout=True,
     if proc.returncode:
         if raise_on_returncode:
             if all_output:
-                logger.notify('Complete output from command %s:' % command_desc)
+                logger.notify('Complete output from command {0!s}:'.format(command_desc))
                 logger.notify('\n'.join(all_output) + '\n----------------------------------------')
             raise InstallationError(
-                "Command %s failed with error code %s"
-                % (command_desc, proc.returncode))
+                "Command {0!s} failed with error code {1!s}".format(command_desc, proc.returncode))
         else:
             logger.warn(
-                "Command %s had error code %s"
-                % (command_desc, proc.returncode))
+                "Command {0!s} had error code {1!s}".format(command_desc, proc.returncode))
     if stdout is not None:
         return ''.join(all_output)
 

--- a/jython-installer/src/main/resources/Lib/site-packages/pip/_pkgutil.py
+++ b/jython-installer/src/main/resources/Lib/site-packages/pip/_pkgutil.py
@@ -541,8 +541,7 @@ def extend_path(path, name):
                 f = open(pkgfile)
             except IOError:
                 msg = sys.exc_info()[1]
-                sys.stderr.write("Can't open %s: %s\n" %
-                                 (pkgfile, msg))
+                sys.stderr.write("Can't open {0!s}: {1!s}\n".format(pkgfile, msg))
             else:
                 for line in f:
                     line = line.rstrip('\n')

--- a/jython-installer/src/main/resources/Lib/site-packages/pip/basecommand.py
+++ b/jython-installer/src/main/resources/Lib/site-packages/pip/basecommand.py
@@ -32,7 +32,7 @@ class Command(object):
         assert self.name
         self.parser = ConfigOptionParser(
             usage=self.usage,
-            prog='%s %s' % (sys.argv[0], self.name),
+            prog='{0!s} {1!s}'.format(sys.argv[0], self.name),
             version=parser.version,
             formatter=UpdatingDefaultsHelpFormatter(),
             name=self.name)
@@ -99,9 +99,9 @@ class Command(object):
                         sys.exit(3)
                 else:
                     options.venv = os.environ.get('VIRTUAL_ENV')
-                    logger.info('Using already activated environment %s' % options.venv)
+                    logger.info('Using already activated environment {0!s}'.format(options.venv))
         if options.venv:
-            logger.info('Running in environment %s' % options.venv)
+            logger.info('Running in environment {0!s}'.format(options.venv))
             site_packages=False
             if options.site_packages:
                 site_packages=True
@@ -127,19 +127,19 @@ class Command(object):
         except (InstallationError, UninstallationError):
             e = sys.exc_info()[1]
             logger.fatal(str(e))
-            logger.info('Exception information:\n%s' % format_exc())
+            logger.info('Exception information:\n{0!s}'.format(format_exc()))
             exit = 1
         except BadCommand:
             e = sys.exc_info()[1]
             logger.fatal(str(e))
-            logger.info('Exception information:\n%s' % format_exc())
+            logger.info('Exception information:\n{0!s}'.format(format_exc()))
             exit = 1
         except KeyboardInterrupt:
             logger.fatal('Operation cancelled by user')
-            logger.info('Exception information:\n%s' % format_exc())
+            logger.info('Exception information:\n{0!s}'.format(format_exc()))
             exit = 1
         except:
-            logger.fatal('Exception:\n%s' % format_exc())
+            logger.fatal('Exception:\n{0!s}'.format(format_exc()))
             exit = 2
 
         if log_fp is not None:
@@ -147,7 +147,7 @@ class Command(object):
         if exit:
             log_fn = options.log_file
             text = '\n'.join(complete_log)
-            logger.fatal('Storing complete log in %s' % log_fn)
+            logger.fatal('Storing complete log in {0!s}'.format(log_fn))
             log_fp = open_logfile(log_fn, 'w')
             log_fp.write(text)
             log_fp.close()
@@ -179,13 +179,13 @@ def open_logfile(filename, mode='a'):
 
     log_fp = open(filename, mode)
     if exists:
-        log_fp.write('%s\n' % ('-'*60))
-        log_fp.write('%s run on %s\n' % (sys.argv[0], time.strftime('%c')))
+        log_fp.write('{0!s}\n'.format(('-'*60)))
+        log_fp.write('{0!s} run on {1!s}\n'.format(sys.argv[0], time.strftime('%c')))
     return log_fp
 
 
 def load_command(name):
-    full_name = 'pip.commands.%s' % name
+    full_name = 'pip.commands.{0!s}'.format(name)
     if full_name in sys.modules:
         return
     try:

--- a/jython-installer/src/main/resources/Lib/site-packages/pip/baseparser.py
+++ b/jython-installer/src/main/resources/Lib/site-packages/pip/baseparser.py
@@ -53,7 +53,7 @@ class ConfigOptionParser(optparse.OptionParser):
         for key, val in config.items():
             key = key.replace('_', '-')
             if not key.startswith('--'):
-                key = '--%s' % key # only prefer long opts
+                key = '--{0!s}'.format(key) # only prefer long opts
             option = self.get_option(key)
             if option is not None:
                 # ignore empty values
@@ -70,7 +70,7 @@ class ConfigOptionParser(optparse.OptionParser):
                     val = option.convert_value(key, val)
                 except optparse.OptionValueError:
                     e = sys.exc_info()[1]
-                    print("An error occured during configuration: %s" % e)
+                    print("An error occured during configuration: {0!s}".format(e))
                     sys.exit(3)
                 defaults[option.dest] = val
         return defaults
@@ -104,7 +104,7 @@ class ConfigOptionParser(optparse.OptionParser):
 
 try:
     pip_dist = pkg_resources.get_distribution('pip')
-    version = '%s from %s (python %s)' % (
+    version = '{0!s} from {1!s} (python {2!s})'.format(
         pip_dist, pip_dist.location, sys.version[:3])
 except pkg_resources.DistributionNotFound:
     # when running pip.py without installing

--- a/jython-installer/src/main/resources/Lib/site-packages/pip/commands/bundle.py
+++ b/jython-installer/src/main/resources/Lib/site-packages/pip/commands/bundle.py
@@ -23,8 +23,7 @@ class BundleCommand(InstallCommand):
             options.src_dir = backup_dir(src_prefix, '-bundle')
         # We have to get everything when creating a bundle:
         options.ignore_installed = True
-        logger.notify('Putting temporary build files in %s and source/develop files in %s'
-                      % (display_path(options.build_dir), display_path(options.src_dir)))
+        logger.notify('Putting temporary build files in {0!s} and source/develop files in {1!s}'.format(display_path(options.build_dir), display_path(options.src_dir)))
         self.bundle_filename = args.pop(0)
         requirement_set = super(BundleCommand, self).run(options, args)
         return requirement_set

--- a/jython-installer/src/main/resources/Lib/site-packages/pip/commands/completion.py
+++ b/jython-installer/src/main/resources/Lib/site-packages/pip/commands/completion.py
@@ -55,6 +55,6 @@ class CompletionCommand(Command):
             script = COMPLETION_SCRIPTS.get(options.shell, '')
             print(BASE_COMPLETION % {'script': script, 'shell': options.shell})
         else:
-            sys.stderr.write('ERROR: You must pass %s\n' % ' or '.join(shell_options))
+            sys.stderr.write('ERROR: You must pass {0!s}\n'.format(' or '.join(shell_options)))
 
 CompletionCommand()

--- a/jython-installer/src/main/resources/Lib/site-packages/pip/commands/freeze.py
+++ b/jython-installer/src/main/resources/Lib/site-packages/pip/commands/freeze.py
@@ -62,7 +62,7 @@ class FreezeCommand(Command):
             if '#egg=' in link:
                 dependency_links.append(link)
         for link in find_links:
-            f.write('-f %s\n' % link)
+            f.write('-f {0!s}\n'.format(link))
         installations = {}
         for dist in get_installed_distributions(local_only=local_only):
             req = pip.FrozenRequirement.from_dist(dist, dependency_links, find_tags=find_tags)
@@ -91,13 +91,11 @@ class FreezeCommand(Command):
                 else:
                     line_req = InstallRequirement.from_line(line)
                 if not line_req.name:
-                    logger.notify("Skipping line because it's not clear what it would install: %s"
-                                  % line.strip())
+                    logger.notify("Skipping line because it's not clear what it would install: {0!s}".format(line.strip()))
                     logger.notify("  (add #egg=PackageName to the URL to avoid this warning)")
                     continue
                 if line_req.name not in installations:
-                    logger.warn("Requirement file contains %s, but that package is not installed"
-                                % line.strip())
+                    logger.warn("Requirement file contains {0!s}, but that package is not installed".format(line.strip()))
                     continue
                 f.write(str(installations[line_req.name]))
                 del installations[line_req.name]

--- a/jython-installer/src/main/resources/Lib/site-packages/pip/commands/help.py
+++ b/jython-installer/src/main/resources/Lib/site-packages/pip/commands/help.py
@@ -14,7 +14,7 @@ class HelpCommand(Command):
             ## FIXME: handle errors better here
             command = args[0]
             if command not in command_dict:
-                raise InstallationError('No command with the name: %s' % command)
+                raise InstallationError('No command with the name: {0!s}'.format(command))
             command = command_dict[command]
             command.parser.print_help()
             return
@@ -25,7 +25,7 @@ class HelpCommand(Command):
         for command in commands:
             if command.hidden:
                 continue
-            print('  %s: %s' % (command.name, command.summary))
+            print('  {0!s}: {1!s}'.format(command.name, command.summary))
 
 
 HelpCommand()

--- a/jython-installer/src/main/resources/Lib/site-packages/pip/commands/install.py
+++ b/jython-installer/src/main/resources/Lib/site-packages/pip/commands/install.py
@@ -80,7 +80,7 @@ class InstallCommand(Command):
             dest='build_dir',
             metavar='DIR',
             default=None,
-            help='Unpack packages into DIR (default %s) and build from there' % build_prefix)
+            help='Unpack packages into DIR (default {0!s}) and build from there'.format(build_prefix))
         self.parser.add_option(
             '-d', '--download', '--download-dir', '--download-directory',
             dest='download_dir',
@@ -98,7 +98,7 @@ class InstallCommand(Command):
             dest='src_dir',
             metavar='DIR',
             default=None,
-            help='Check out --editable packages into DIR (default %s)' % src_prefix)
+            help='Check out --editable packages into DIR (default {0!s})'.format(src_prefix))
 
         self.parser.add_option(
             '-U', '--upgrade',
@@ -177,7 +177,7 @@ class InstallCommand(Command):
         global_options = options.global_options or []
         index_urls = [options.index_url] + options.extra_index_urls
         if options.no_index:
-            logger.notify('Ignoring indexes: %s' % ','.join(index_urls))
+            logger.notify('Ignoring indexes: {0!s}'.format(','.join(index_urls)))
             index_urls = []
 
         finder = self._build_package_finder(options, index_urls)
@@ -229,15 +229,15 @@ class InstallCommand(Command):
             installed = ' '.join([req.name for req in
                                   requirement_set.successfully_installed])
             if installed:
-                logger.notify('Successfully installed %s' % installed)
+                logger.notify('Successfully installed {0!s}'.format(installed))
         elif not self.bundle:
             downloaded = ' '.join([req.name for req in
                                    requirement_set.successfully_downloaded])
             if downloaded:
-                logger.notify('Successfully downloaded %s' % downloaded)
+                logger.notify('Successfully downloaded {0!s}'.format(downloaded))
         elif self.bundle:
             requirement_set.create_bundle(self.bundle_filename)
-            logger.notify('Created bundle in %s' % self.bundle_filename)
+            logger.notify('Created bundle in {0!s}'.format(self.bundle_filename))
         # Clean up
         if not options.no_install:
             requirement_set.cleanup_files(bundle=self.bundle)

--- a/jython-installer/src/main/resources/Lib/site-packages/pip/commands/search.py
+++ b/jython-installer/src/main/resources/Lib/site-packages/pip/commands/search.py
@@ -82,7 +82,7 @@ def print_results(hits, name_column_width=25, terminal_width=None):
             # wrap and indent summary to fit terminal
             summary = textwrap.wrap(summary, terminal_width - name_column_width - 5)
             summary = ('\n' + ' ' * (name_column_width + 3)).join(summary)
-        line = '%s - %s' % (name.ljust(name_column_width), summary)
+        line = '{0!s} - {1!s}'.format(name.ljust(name_column_width), summary)
         try:
             logger.notify(line)
             if name in installed_packages:
@@ -91,10 +91,10 @@ def print_results(hits, name_column_width=25, terminal_width=None):
                 try:
                     latest = highest_version(hit['versions'])
                     if dist.version == latest:
-                        logger.notify('INSTALLED: %s (latest)' % dist.version)
+                        logger.notify('INSTALLED: {0!s} (latest)'.format(dist.version))
                     else:
-                        logger.notify('INSTALLED: %s' % dist.version)
-                        logger.notify('LATEST:    %s' % latest)
+                        logger.notify('INSTALLED: {0!s}'.format(dist.version))
+                        logger.notify('LATEST:    {0!s}'.format(latest))
                 finally:
                     logger.indent -= 2
         except UnicodeEncodeError:

--- a/jython-installer/src/main/resources/Lib/site-packages/pip/commands/zip.py
+++ b/jython-installer/src/main/resources/Lib/site-packages/pip/commands/zip.py
@@ -76,13 +76,11 @@ class ZipCommand(Command):
                         match_any.add(match)
                         break
             else:
-                logger.debug("Skipping path %s because it doesn't match %s"
-                             % (path, ', '.join(self.select_paths)))
+                logger.debug("Skipping path {0!s} because it doesn't match {1!s}".format(path, ', '.join(self.select_paths)))
         for match in self.select_paths:
             if match not in match_any and '*' not in match:
                 result.append(match)
-                logger.debug("Adding path %s because it doesn't match anything already on sys.path"
-                             % match)
+                logger.debug("Adding path {0!s} because it doesn't match anything already on sys.path".format(match))
         return result
 
     def run(self, options, args):
@@ -98,12 +96,10 @@ class ZipCommand(Command):
             module_name, filename = self.find_package(arg)
             if options.unzip and os.path.isdir(filename):
                 raise InstallationError(
-                    'The module %s (in %s) is not a zip file; cannot be unzipped'
-                    % (module_name, filename))
+                    'The module {0!s} (in {1!s}) is not a zip file; cannot be unzipped'.format(module_name, filename))
             elif not options.unzip and not os.path.isdir(filename):
                 raise InstallationError(
-                    'The module %s (in %s) is not a directory; cannot be zipped'
-                    % (module_name, filename))
+                    'The module {0!s} (in {1!s}) is not a directory; cannot be zipped'.format(module_name, filename))
             packages.append((module_name, filename))
         last_status = None
         for module_name, filename in packages:
@@ -117,15 +113,13 @@ class ZipCommand(Command):
         zip_filename = os.path.dirname(filename)
         if not os.path.isfile(zip_filename) and zipfile.is_zipfile(zip_filename):
             raise InstallationError(
-                'Module %s (in %s) isn\'t located in a zip file in %s'
-                % (module_name, filename, zip_filename))
+                'Module {0!s} (in {1!s}) isn\'t located in a zip file in {2!s}'.format(module_name, filename, zip_filename))
         package_path = os.path.dirname(zip_filename)
         if not package_path in self.paths():
             logger.warn(
-                'Unpacking %s into %s, but %s is not on sys.path'
-                % (display_path(zip_filename), display_path(package_path),
+                'Unpacking {0!s} into {1!s}, but {2!s} is not on sys.path'.format(display_path(zip_filename), display_path(package_path),
                    display_path(package_path)))
-        logger.notify('Unzipping %s (in %s)' % (module_name, display_path(zip_filename)))
+        logger.notify('Unzipping {0!s} (in {1!s})'.format(module_name, display_path(zip_filename)))
         if self.simulate:
             logger.notify('Skipping remaining operations because of --simulate')
             return
@@ -151,11 +145,11 @@ class ZipCommand(Command):
                     to_save.append((name, zip.read(name)))
             zip.close()
             if not to_save:
-                logger.info('Removing now-empty zip file %s' % display_path(zip_filename))
+                logger.info('Removing now-empty zip file {0!s}'.format(display_path(zip_filename)))
                 os.unlink(zip_filename)
                 self.remove_filename_from_pth(zip_filename)
             else:
-                logger.info('Removing entries in %s/ from zip file %s' % (module_name, display_path(zip_filename)))
+                logger.info('Removing entries in {0!s}/ from zip file {1!s}'.format(module_name, display_path(zip_filename)))
                 zip = zipfile.ZipFile(zip_filename, 'w')
                 for name, content in to_save:
                     zip.writestr(name, content)
@@ -165,7 +159,7 @@ class ZipCommand(Command):
 
     def zip_package(self, module_name, filename, no_pyc):
         orig_filename = filename
-        logger.notify('Zip %s (in %s)' % (module_name, display_path(filename)))
+        logger.notify('Zip {0!s} (in {1!s})'.format(module_name, display_path(filename)))
         logger.indent += 2
         if filename.endswith('.egg'):
             dest_filename = filename
@@ -175,11 +169,11 @@ class ZipCommand(Command):
             ## FIXME: I think this needs to be undoable:
             if filename == dest_filename:
                 filename = backup_dir(orig_filename)
-                logger.notify('Moving %s aside to %s' % (orig_filename, filename))
+                logger.notify('Moving {0!s} aside to {1!s}'.format(orig_filename, filename))
                 if not self.simulate:
                     shutil.move(orig_filename, filename)
             try:
-                logger.info('Creating zip file in %s' % display_path(dest_filename))
+                logger.info('Creating zip file in {0!s}'.format(display_path(dest_filename)))
                 if not self.simulate:
                     zip = zipfile.ZipFile(dest_filename, 'w')
                     zip.writestr(module_name + '/', '')
@@ -196,7 +190,7 @@ class ZipCommand(Command):
                                 else:
                                     zip.write(full, dest)
                     zip.close()
-                logger.info('Removing old directory %s' % display_path(filename))
+                logger.info('Removing old directory {0!s}'.format(display_path(filename)))
                 if not self.simulate:
                     rmtree(filename)
             except:
@@ -215,10 +209,9 @@ class ZipCommand(Command):
             new_lines = [
                 l for l in lines if l.strip() != filename]
             if lines != new_lines:
-                logger.info('Removing reference to %s from .pth file %s'
-                            % (display_path(filename), display_path(pth)))
+                logger.info('Removing reference to {0!s} from .pth file {1!s}'.format(display_path(filename), display_path(pth)))
                 if not [line for line in new_lines if line]:
-                    logger.info('%s file would be empty: deleting' % display_path(pth))
+                    logger.info('{0!s} file would be empty: deleting'.format(display_path(pth)))
                     if not self.simulate:
                         os.unlink(pth)
                 else:
@@ -227,13 +220,13 @@ class ZipCommand(Command):
                         f.writelines(new_lines)
                         f.close()
                 return
-        logger.warn('Cannot find a reference to %s in any .pth file' % display_path(filename))
+        logger.warn('Cannot find a reference to {0!s} in any .pth file'.format(display_path(filename)))
 
     def add_filename_to_pth(self, filename):
         path = os.path.dirname(filename)
         dest = os.path.join(path, filename + '.pth')
         if path not in self.paths():
-            logger.warn('Adding .pth file %s, but it is not on sys.path' % display_path(dest))
+            logger.warn('Adding .pth file {0!s}, but it is not on sys.path'.format(display_path(dest)))
         if not self.simulate:
             if os.path.exists(dest):
                 f = open(dest)
@@ -273,7 +266,7 @@ class ZipCommand(Command):
                 zip.close()
         ## FIXME: need special error for package.py case:
         raise InstallationError(
-            'No package with the name %s found' % package)
+            'No package with the name {0!s} found'.format(package))
 
     def list(self, options, args):
         if args:
@@ -285,12 +278,12 @@ class ZipCommand(Command):
             basename = os.path.basename(path.rstrip(os.path.sep))
             if os.path.isfile(path) and zipfile.is_zipfile(path):
                 if os.path.dirname(path) not in self.paths():
-                    logger.notify('Zipped egg: %s' % display_path(path))
+                    logger.notify('Zipped egg: {0!s}'.format(display_path(path)))
                 continue
             if (basename != 'site-packages' and basename != 'dist-packages'
                 and not path.replace('\\', '/').endswith('lib/python')):
                 continue
-            logger.notify('In %s:' % display_path(path))
+            logger.notify('In {0!s}:'.format(display_path(path)))
             logger.indent += 2
             zipped = []
             unzipped = []
@@ -300,7 +293,7 @@ class ZipCommand(Command):
                     if ext in ('.pth', '.egg-info', '.egg-link'):
                         continue
                     if ext == '.py':
-                        logger.info('Not displaying %s: not a package' % display_path(filename))
+                        logger.info('Not displaying {0!s}: not a package'.format(display_path(filename)))
                         continue
                     full = os.path.join(path, filename)
                     if os.path.isdir(full):
@@ -308,7 +301,7 @@ class ZipCommand(Command):
                     elif zipfile.is_zipfile(full):
                         zipped.append(filename)
                     else:
-                        logger.info('Unknown file: %s' % display_path(filename))
+                        logger.info('Unknown file: {0!s}'.format(display_path(filename)))
                 if zipped:
                     logger.notify('Zipped packages:')
                     logger.indent += 2
@@ -326,7 +319,7 @@ class ZipCommand(Command):
                     logger.indent += 2
                     try:
                         for filename, count in unzipped:
-                            logger.notify('%s  (%i files)' % (filename, count))
+                            logger.notify('{0!s}  ({1:d} files)'.format(filename, count))
                     finally:
                         logger.indent -= 2
                 else:

--- a/jython-installer/src/main/resources/Lib/site-packages/pip/download.py
+++ b/jython-installer/src/main/resources/Lib/site-packages/pip/download.py
@@ -34,8 +34,7 @@ def get_file_content(url, comes_from=None):
         if (scheme == 'file' and comes_from
             and comes_from.startswith('http')):
             raise InstallationError(
-                'Requirements file %s references URL %s, which is local'
-                % (comes_from, url))
+                'Requirements file {0!s} references URL {1!s}, which is local'.format(comes_from, url))
         if scheme == 'file':
             path = url.split(':', 1)[1]
             path = path.replace('\\', '/')
@@ -55,7 +54,7 @@ def get_file_content(url, comes_from=None):
         content = f.read()
     except IOError:
         e = sys.exc_info()[1]
-        raise InstallationError('Could not open requirements file: %s' % str(e))
+        raise InstallationError('Could not open requirements file: {0!s}'.format(str(e)))
     else:
         f.close()
     return url, content
@@ -112,7 +111,7 @@ class URLOpener(object):
         # see if we have a password stored
         if stored_username is None:
             if username is None and self.prompting:
-                username = urllib.quote(raw_input('User for %s: ' % netloc))
+                username = urllib.quote(raw_input('User for {0!s}: '.format(netloc)))
                 password = urllib.quote(getpass.getpass('Password: '))
             if username and password:
                 self.passman.add_password(None, netloc, username, password)
@@ -161,13 +160,13 @@ class URLOpener(object):
             return url, None, None
         elif password is None and self.prompting:
             # remove the auth credentials from the url part
-            netloc = netloc.replace('%s@' % username, '', 1)
+            netloc = netloc.replace('{0!s}@'.format(username), '', 1)
             # prompt for the password
-            prompt = 'Password for %s@%s: ' % (username, netloc)
+            prompt = 'Password for {0!s}@{1!s}: '.format(username, netloc)
             password = urllib.quote(getpass.getpass(prompt))
         else:
             # remove the auth credentials from the url part
-            netloc = netloc.replace('%s:%s@' % (username, password), '', 1)
+            netloc = netloc.replace('{0!s}:{1!s}@'.format(username, password), '', 1)
 
         target_url = urlparse.urlunsplit((scheme, netloc, path, query, frag))
         return target_url, username, password
@@ -187,9 +186,9 @@ class URLOpener(object):
                     user, password = user_password.split(':', 1)
                 else:
                     user = user_password
-                    prompt = 'Password for %s@%s: ' % (user, server_port)
+                    prompt = 'Password for {0!s}@{1!s}: '.format(user, server_port)
                     password = urllib.quote(getpass.getpass(prompt))
-                return '%s:%s@%s' % (user, password, server_port)
+                return '{0!s}:{1!s}@{2!s}'.format(user, password, server_port)
             else:
                 return proxystr
         else:
@@ -211,7 +210,7 @@ def url_to_path(url):
     Convert a file: URL to a path.
     """
     assert url.startswith('file:'), (
-        "You can only turn file: urls into filenames (not %r)" % url)
+        "You can only turn file: urls into filenames (not {0!r})".format(url))
     path = url[len('file:'):].lstrip('/')
     path = urllib.unquote(path)
     if _url_drive_re.match(path):
@@ -273,7 +272,7 @@ def geturl(urllib2_resp):
         return url
     else:
         # FIXME: write a good test to cover it
-        return '%s://%s' % (scheme, rest)
+        return '{0!s}://{1!s}'.format(scheme, rest)
 
 
 def is_archive_file(name):
@@ -323,9 +322,8 @@ def is_file_url(link):
 def _check_md5(download_hash, link):
     download_hash = download_hash.hexdigest()
     if download_hash != link.md5_hash:
-        logger.fatal("MD5 hash of the package %s (%s) doesn't match the expected hash %s!"
-                     % (link, download_hash, link.md5_hash))
-        raise InstallationError('Bad MD5 hash for package %s' % link)
+        logger.fatal("MD5 hash of the package {0!s} ({1!s}) doesn't match the expected hash {2!s}!".format(link, download_hash, link.md5_hash))
+        raise InstallationError('Bad MD5 hash for package {0!s}'.format(link))
 
 
 def _get_md5_from_file(target_file, link):
@@ -356,12 +354,12 @@ def _download_url(resp, link, temp_location):
         if show_progress:
             ## FIXME: the URL can get really long in this message:
             if total_length:
-                logger.start_progress('Downloading %s (%s): ' % (show_url, format_size(total_length)))
+                logger.start_progress('Downloading {0!s} ({1!s}): '.format(show_url, format_size(total_length)))
             else:
-                logger.start_progress('Downloading %s (unknown size): ' % show_url)
+                logger.start_progress('Downloading {0!s} (unknown size): '.format(show_url))
         else:
-            logger.notify('Downloading %s' % show_url)
-        logger.debug('Downloading from URL %s' % link)
+            logger.notify('Downloading {0!s}'.format(show_url))
+        logger.debug('Downloading from URL {0!s}'.format(link))
 
         while True:
             chunk = resp.read(4096)
@@ -370,16 +368,16 @@ def _download_url(resp, link, temp_location):
             downloaded += len(chunk)
             if show_progress:
                 if not total_length:
-                    logger.show_progress('%s' % format_size(downloaded))
+                    logger.show_progress('{0!s}'.format(format_size(downloaded)))
                 else:
-                    logger.show_progress('%3i%%  %s' % (100*downloaded/total_length, format_size(downloaded)))
+                    logger.show_progress('{0:3d}%  {1!s}'.format(100*downloaded/total_length, format_size(downloaded)))
             if link.md5_hash:
                 download_hash.update(chunk)
             fp.write(chunk)
         fp.close()
     finally:
         if show_progress:
-            logger.end_progress('%s downloaded' % format_size(downloaded))
+            logger.end_progress('{0!s} downloaded'.format(format_size(downloaded)))
     return download_hash
 
 
@@ -387,22 +385,20 @@ def _copy_file(filename, location, content_type, link):
     copy = True
     download_location = os.path.join(location, link.filename)
     if os.path.exists(download_location):
-        response = ask('The file %s exists. (i)gnore, (w)ipe, (b)ackup '
-                       % display_path(download_location), ('i', 'w', 'b'))
+        response = ask('The file {0!s} exists. (i)gnore, (w)ipe, (b)ackup '.format(display_path(download_location)), ('i', 'w', 'b'))
         if response == 'i':
             copy = False
         elif response == 'w':
-            logger.warn('Deleting %s' % display_path(download_location))
+            logger.warn('Deleting {0!s}'.format(display_path(download_location)))
             os.remove(download_location)
         elif response == 'b':
             dest_file = backup_dir(download_location)
-            logger.warn('Backing up %s to %s'
-                        % (display_path(download_location), display_path(dest_file)))
+            logger.warn('Backing up {0!s} to {1!s}'.format(display_path(download_location), display_path(dest_file)))
             shutil.move(download_location, dest_file)
     if copy:
         shutil.copy(filename, download_location)
         logger.indent -= 2
-        logger.notify('Saved %s' % display_path(download_location))
+        logger.notify('Saved {0!s}'.format(display_path(download_location)))
 
 
 def unpack_http_url(link, location, download_cache, only_download):
@@ -424,7 +420,7 @@ def unpack_http_url(link, location, download_cache, only_download):
         if link.md5_hash:
             download_hash = _get_md5_from_file(target_file, link)
         temp_location = target_file
-        logger.notify('Using download cache from %s' % target_file)
+        logger.notify('Using download cache from {0!s}'.format(target_file))
     else:
         resp = _get_response_from_url(target_url, link)
         content_type = resp.info()['content-type']
@@ -465,12 +461,12 @@ def _get_response_from_url(target_url, link):
         resp = urlopen(target_url)
     except urllib2.HTTPError:
         e = sys.exc_info()[1]
-        logger.fatal("HTTP error %s while getting %s" % (e.code, link))
+        logger.fatal("HTTP error {0!s} while getting {1!s}".format(e.code, link))
         raise
     except IOError:
         e = sys.exc_info()[1]
         # Typically an FTP error
-        logger.fatal("Error %s while getting %s" % (e, link))
+        logger.fatal("Error {0!s} while getting {1!s}".format(e, link))
         raise
     return resp
 

--- a/jython-installer/src/main/resources/Lib/site-packages/pip/index.py
+++ b/jython-installer/src/main/resources/Lib/site-packages/pip/index.py
@@ -44,7 +44,7 @@ class PackageFinder(object):
         self.logged_links = set()
         if use_mirrors:
             self.mirror_urls = self._get_mirror_urls(mirrors, main_mirror_url)
-            logger.info('Using PyPI mirrors: %s' % ', '.join(self.mirror_urls))
+            logger.info('Using PyPI mirrors: {0!s}'.format(', '.join(self.mirror_urls)))
         else:
             self.mirror_urls = []
 
@@ -126,16 +126,16 @@ class PackageFinder(object):
         file_locations, url_locations = self._sort_locations(locations)
 
         locations = [Link(url) for url in url_locations]
-        logger.debug('URLs to search for versions for %s:' % req)
+        logger.debug('URLs to search for versions for {0!s}:'.format(req))
         for location in locations:
-            logger.debug('* %s' % location)
+            logger.debug('* {0!s}'.format(location))
         found_versions = []
         found_versions.extend(
             self._package_versions(
                 [Link(url, '-f') for url in self.find_links], req.name.lower()))
         page_versions = []
         for page in self._get_pages(locations, req):
-            logger.debug('Analyzing links from page %s' % page.url)
+            logger.debug('Analyzing links from page {0!s}'.format(page.url))
             logger.indent += 2
             try:
                 page_versions.extend(self._package_versions(page.links, req.name.lower()))
@@ -144,48 +144,42 @@ class PackageFinder(object):
         dependency_versions = list(self._package_versions(
             [Link(url) for url in self.dependency_links], req.name.lower()))
         if dependency_versions:
-            logger.info('dependency_links found: %s' % ', '.join([link.url for parsed, link, version in dependency_versions]))
+            logger.info('dependency_links found: {0!s}'.format(', '.join([link.url for parsed, link, version in dependency_versions])))
         file_versions = list(self._package_versions(
                 [Link(url) for url in file_locations], req.name.lower()))
         if not found_versions and not page_versions and not dependency_versions and not file_versions:
-            logger.fatal('Could not find any downloads that satisfy the requirement %s' % req)
-            raise DistributionNotFound('No distributions at all found for %s' % req)
+            logger.fatal('Could not find any downloads that satisfy the requirement {0!s}'.format(req))
+            raise DistributionNotFound('No distributions at all found for {0!s}'.format(req))
         if req.satisfied_by is not None:
             found_versions.append((req.satisfied_by.parsed_version, Inf, req.satisfied_by.version))
         if file_versions:
             file_versions.sort(reverse=True)
-            logger.info('Local files found: %s' % ', '.join([url_to_path(link.url) for parsed, link, version in file_versions]))
+            logger.info('Local files found: {0!s}'.format(', '.join([url_to_path(link.url) for parsed, link, version in file_versions])))
             found_versions = file_versions + found_versions
         all_versions = found_versions + page_versions + dependency_versions
         applicable_versions = []
         for (parsed_version, link, version) in all_versions:
             if version not in req.req:
-                logger.info("Ignoring link %s, version %s doesn't match %s"
-                            % (link, version, ','.join([''.join(s) for s in req.req.specs])))
+                logger.info("Ignoring link {0!s}, version {1!s} doesn't match {2!s}".format(link, version, ','.join([''.join(s) for s in req.req.specs])))
                 continue
             applicable_versions.append((link, version))
         applicable_versions = sorted(applicable_versions, key=lambda v: pkg_resources.parse_version(v[1]), reverse=True)
         existing_applicable = bool([link for link, version in applicable_versions if link is Inf])
         if not upgrade and existing_applicable:
             if applicable_versions[0][1] is Inf:
-                logger.info('Existing installed version (%s) is most up-to-date and satisfies requirement'
-                            % req.satisfied_by.version)
+                logger.info('Existing installed version ({0!s}) is most up-to-date and satisfies requirement'.format(req.satisfied_by.version))
             else:
-                logger.info('Existing installed version (%s) satisfies requirement (most up-to-date version is %s)'
-                            % (req.satisfied_by.version, applicable_versions[0][1]))
+                logger.info('Existing installed version ({0!s}) satisfies requirement (most up-to-date version is {1!s})'.format(req.satisfied_by.version, applicable_versions[0][1]))
             return None
         if not applicable_versions:
-            logger.fatal('Could not find a version that satisfies the requirement %s (from versions: %s)'
-                         % (req, ', '.join([version for parsed_version, link, version in found_versions])))
-            raise DistributionNotFound('No distributions matching the version for %s' % req)
+            logger.fatal('Could not find a version that satisfies the requirement {0!s} (from versions: {1!s})'.format(req, ', '.join([version for parsed_version, link, version in found_versions])))
+            raise DistributionNotFound('No distributions matching the version for {0!s}'.format(req))
         if applicable_versions[0][0] is Inf:
             # We have an existing version, and its the best version
-            logger.info('Installed version (%s) is most up-to-date (past versions: %s)'
-                        % (req.satisfied_by.version, ', '.join([version for link, version in applicable_versions[1:]]) or 'none'))
+            logger.info('Installed version ({0!s}) is most up-to-date (past versions: {1!s})'.format(req.satisfied_by.version, ', '.join([version for link, version in applicable_versions[1:]]) or 'none'))
             return None
         if len(applicable_versions) > 1:
-            logger.info('Using version %s (newest of versions: %s)' %
-                        (applicable_versions[0][1], ', '.join([version for link, version in applicable_versions])))
+            logger.info('Using version {0!s} (newest of versions: {1!s})'.format(applicable_versions[0][1], ', '.join([version for link, version in applicable_versions])))
         return applicable_versions[0][0]
 
     def _find_url_name(self, index_url, url_name, req):
@@ -197,13 +191,13 @@ class PackageFinder(object):
             index_url.url += '/'
         page = self._get_page(index_url, req)
         if page is None:
-            logger.fatal('Cannot fetch index base URL %s' % index_url)
+            logger.fatal('Cannot fetch index base URL {0!s}'.format(index_url))
             return
         norm_name = normalize_name(req.url_name)
         for link in page.links:
             base = posixpath.basename(link.path.rstrip('/'))
             if norm_name == normalize_name(base):
-                logger.notify('Real name of requirement %s is %s' % (url_name, base))
+                logger.notify('Real name of requirement {0!s} is {1!s}'.format(url_name, base))
                 return base
         return None
 
@@ -279,7 +273,7 @@ class PackageFinder(object):
             egg_info, ext = link.splitext()
             if not ext:
                 if link not in self.logged_links:
-                    logger.debug('Skipping link %s; not a file' % link)
+                    logger.debug('Skipping link {0!s}; not a file'.format(link))
                     self.logged_links.add(link)
                 return []
             if egg_info.endswith('.tar'):
@@ -288,21 +282,21 @@ class PackageFinder(object):
                 ext = '.tar' + ext
             if ext not in ('.tar.gz', '.tar.bz2', '.tar', '.tgz', '.zip'):
                 if link not in self.logged_links:
-                    logger.debug('Skipping link %s; unknown archive format: %s' % (link, ext))
+                    logger.debug('Skipping link {0!s}; unknown archive format: {1!s}'.format(link, ext))
                     self.logged_links.add(link)
                 return []
         version = self._egg_info_matches(egg_info, search_name, link)
         if version is None:
-            logger.debug('Skipping link %s; wrong project name (not %s)' % (link, search_name))
+            logger.debug('Skipping link {0!s}; wrong project name (not {1!s})'.format(link, search_name))
             return []
         match = self._py_version_re.search(version)
         if match:
             version = version[:match.start()]
             py_version = match.group(1)
             if py_version != sys.version[:3]:
-                logger.debug('Skipping %s because Python version is incorrect' % link)
+                logger.debug('Skipping {0!s} because Python version is incorrect'.format(link))
                 return []
-        logger.debug('Found link %s, version: %s' % (link, version))
+        logger.debug('Found link {0!s}, version: {1!s}'.format(link, version))
         return [(pkg_resources.parse_version(version),
                link,
                version)]
@@ -310,7 +304,7 @@ class PackageFinder(object):
     def _egg_info_matches(self, egg_info, search_name, link):
         match = self._egg_info_re.search(egg_info)
         if not match:
-            logger.debug('Could not parse version from link: %s' % link)
+            logger.debug('Could not parse version from link: {0!s}'.format(link))
             return None
         name = match.group(0).lower()
         # To match the "safe" name that pkg_resources creates:
@@ -336,9 +330,9 @@ class PackageFinder(object):
         for mirror_url in mirrors:
             # Make sure we have a valid URL
             if not ("http://" or "https://" or "file://") in mirror_url:
-                mirror_url = "http://%s" % mirror_url
+                mirror_url = "http://{0!s}".format(mirror_url)
             if not mirror_url.endswith("/simple"):
-                mirror_url = "%s/simple/" % mirror_url
+                mirror_url = "{0!s}/simple/".format(mirror_url)
             mirror_urls.add(mirror_url)
 
         return list(mirror_urls)
@@ -404,7 +398,7 @@ class HTMLPage(object):
         from pip.vcs import VcsSupport
         for scheme in VcsSupport.schemes:
             if url.lower().startswith(scheme) and url[len(scheme)] in '+:':
-                logger.debug('Cannot look at %(scheme)s URL %(link)s' % locals())
+                logger.debug('Cannot look at {scheme!s} URL {link!s}'.format(**locals()))
                 return None
 
         if cache is not None:
@@ -423,11 +417,11 @@ class HTMLPage(object):
                         if content_type.lower().startswith('text/html'):
                             break
                         else:
-                            logger.debug('Skipping page %s because of Content-Type: %s' % (link, content_type))
+                            logger.debug('Skipping page {0!s} because of Content-Type: {1!s}'.format(link, content_type))
                             if cache is not None:
                                 cache.set_is_archive(url)
                             return None
-            logger.debug('Getting page %s' % url)
+            logger.debug('Getting page {0!s}'.format(url))
 
             # Tack index.html onto file:// URLs that point to directories
             (scheme, netloc, path, params, query, fragment) = urlparse.urlparse(url)
@@ -436,7 +430,7 @@ class HTMLPage(object):
                 if not url.endswith('/'):
                     url += '/'
                 url = urlparse.urljoin(url, 'index.html')
-                logger.debug(' file: URL is directory, getting %s' % url)
+                logger.debug(' file: URL is directory, getting {0!s}'.format(url))
 
             resp = urlopen(url)
 
@@ -464,8 +458,8 @@ class HTMLPage(object):
             else:
                 log_meth = logger.info
                 level = 1
-            log_meth('Could not fetch URL %s: %s' % (link, desc))
-            log_meth('Will skip URL %s when looking for download links for %s' % (link.url, req))
+            log_meth('Could not fetch URL {0!s}: {1!s}'.format(link, desc))
+            log_meth('Will skip URL {0!s} when looking for download links for {1!s}'.format(link.url, req))
             if cache is not None:
                 cache.add_page_failure(url, level)
             return None
@@ -552,7 +546,7 @@ class HTMLPage(object):
         the link, it will be rewritten to %20 (while not over-quoting
         % or other characters)."""
         return self._clean_re.sub(
-            lambda match: '%%%2x' % ord(match.group(0)), url)
+            lambda match: '%{0:2x}'.format(ord(match.group(0))), url)
 
 
 class Link(object):
@@ -563,12 +557,12 @@ class Link(object):
 
     def __str__(self):
         if self.comes_from:
-            return '%s (from %s)' % (self.url, self.comes_from)
+            return '{0!s} (from {1!s})'.format(self.url, self.comes_from)
         else:
             return self.url
 
     def __repr__(self):
-        return '<Link %s>' % self
+        return '<Link {0!s}>'.format(self)
 
     def __eq__(self, other):
         return self.url == other.url
@@ -580,7 +574,7 @@ class Link(object):
     def filename(self):
         url = self.url_fragment
         name = posixpath.basename(url)
-        assert name, ('URL %r produced no filename' % url)
+        assert name, ('URL {0!r} produced no filename'.format(url))
         return name
 
     @property
@@ -645,7 +639,7 @@ def package_to_requirement(package_name):
         name = package_name
         version = ''
     if version:
-        return '%s==%s' % (name, version)
+        return '{0!s}=={1!s}'.format(name, version)
     else:
         return name
 
@@ -672,7 +666,7 @@ def get_mirrors(hostname=None):
     end_letter = hostname.split(".", 1)
 
     # determine the list from the last one.
-    return ["%s.%s" % (s, end_letter[1]) for s in string_range(end_letter[0])]
+    return ["{0!s}.{1!s}".format(s, end_letter[1]) for s in string_range(end_letter[0])]
 
 
 def string_range(last):

--- a/jython-installer/src/main/resources/Lib/site-packages/pip/log.py
+++ b/jython-installer/src/main/resources/Lib/site-packages/pip/log.py
@@ -69,7 +69,7 @@ class Logger(object):
                     rendered = ' '*self.indent + rendered
                     if self.explicit_levels:
                         ## FIXME: should this be a name, not a level number?
-                        rendered = '%02i %s' % (level, rendered)
+                        rendered = '{0:02d} {1!s}'.format(level, rendered)
                 if hasattr(consumer, 'write'):
                     consumer.write(rendered+'\n')
                 else:
@@ -81,8 +81,7 @@ class Logger(object):
 
     def start_progress(self, msg):
         assert not self.in_progress, (
-            "Tried to start_progress(%r) while in_progress %r"
-            % (msg, self.in_progress))
+            "Tried to start_progress({0!r}) while in_progress {1!r}".format(msg, self.in_progress))
         if self._show_progress():
             sys.stdout.write(' '*self.indent + msg)
             sys.stdout.flush()
@@ -121,7 +120,7 @@ class Logger(object):
                     padding = ' ' * max(0, len(self.last_message)-len(message))
                 else:
                     padding = ''
-                sys.stdout.write('\r%s%s%s%s' % (' '*self.indent, self.in_progress, message, padding))
+                sys.stdout.write('\r{0!s}{1!s}{2!s}{3!s}'.format(' '*self.indent, self.in_progress, message, padding))
                 sys.stdout.flush()
                 self.last_message = message
 

--- a/jython-installer/src/main/resources/Lib/site-packages/pip/req.py
+++ b/jython-installer/src/main/resources/Lib/site-packages/pip/req.py
@@ -107,18 +107,18 @@ class InstallRequirement(object):
         if self.req:
             s = str(self.req)
             if self.url:
-                s += ' from %s' % self.url
+                s += ' from {0!s}'.format(self.url)
         else:
             s = self.url
         if self.satisfied_by is not None:
-            s += ' in %s' % display_path(self.satisfied_by.location)
+            s += ' in {0!s}'.format(display_path(self.satisfied_by.location))
         if self.comes_from:
             if isinstance(self.comes_from, string_types):
                 comes_from = self.comes_from
             else:
                 comes_from = self.comes_from.from_path()
             if comes_from:
-                s += ' (from %s)' % comes_from
+                s += ' (from {0!s})'.format(comes_from)
         return s
 
     def from_path(self):
@@ -166,14 +166,12 @@ class InstallRequirement(object):
             name = self.name
         new_location = os.path.join(new_build_dir, name)
         if not os.path.exists(new_build_dir):
-            logger.debug('Creating directory %s' % new_build_dir)
+            logger.debug('Creating directory {0!s}'.format(new_build_dir))
             _make_build_dir(new_build_dir)
         if os.path.exists(new_location):
             raise InstallationError(
-                'A package already exists in %s; please remove it to continue'
-                % display_path(new_location))
-        logger.debug('Moving package %s from %s to new location %s'
-                     % (self, display_path(old_location), display_path(new_location)))
+                'A package already exists in {0!s}; please remove it to continue'.format(display_path(new_location)))
+        logger.debug('Moving package {0!s} from {1!s} to new location {2!s}'.format(self, display_path(old_location), display_path(new_location)))
         shutil.move(old_location, new_location)
         self._temp_build_dir = new_location
         self.source_dir = new_location
@@ -198,9 +196,9 @@ class InstallRequirement(object):
     def run_egg_info(self, force_root_egg_info=False):
         assert self.source_dir
         if self.name:
-            logger.notify('Running setup.py egg_info for package %s' % self.name)
+            logger.notify('Running setup.py egg_info for package {0!s}'.format(self.name))
         else:
-            logger.notify('Running setup.py egg_info for package from %s' % self.url)
+            logger.notify('Running setup.py egg_info for package from {0!s}'.format(self.url))
         logger.indent += 2
         try:
             script = self._run_setup_py
@@ -224,7 +222,7 @@ class InstallRequirement(object):
             logger.indent -= 2
         if not self.req:
             self.req = pkg_resources.Requirement.parse(
-                "%(Name)s==%(Version)s" % self.pkg_info())
+                "{Name!s}=={Version!s}".format(**self.pkg_info()))
             self.correct_build_location()
 
     ## FIXME: This is a lame hack, entirely for PasteScript which has
@@ -285,8 +283,8 @@ exec(compile(open(__file__).read().replace('\\r\\n', '\\n'), __file__, 'exec'))
                 filenames = [f for f in filenames if f.endswith('.egg-info')]
 
             if not filenames:
-                raise InstallationError('No files/directores in %s (from %s)' % (base, filename))
-            assert filenames, "No files/directories in %s (from %s)" % (base, filename)
+                raise InstallationError('No files/directores in {0!s} (from {1!s})'.format(base, filename))
+            assert filenames, "No files/directories in {0!s} (from {1!s})".format(base, filename)
 
             # if we have more than one match, we pick the toplevel one.  This can
             # easily be the case if there is a dist folder which contains an
@@ -314,7 +312,7 @@ exec(compile(open(__file__).read().replace('\\r\\n', '\\n'), __file__, 'exec'))
         p = FeedParser()
         data = self.egg_info_data('PKG-INFO')
         if not data:
-            logger.warn('No PKG-INFO file found in %s' % display_path(self.egg_info_path('PKG-INFO')))
+            logger.warn('No PKG-INFO file found in {0!s}'.format(display_path(self.egg_info_path('PKG-INFO'))))
         p.feed(data or '')
         return p.close()
 
@@ -355,25 +353,22 @@ exec(compile(open(__file__).read().replace('\\r\\n', '\\n'), __file__, 'exec'))
         version = self.installed_version
         if version not in self.req:
             logger.fatal(
-                'Source in %s has the version %s, which does not match the requirement %s'
-                % (display_path(self.source_dir), version, self))
+                'Source in {0!s} has the version {1!s}, which does not match the requirement {2!s}'.format(display_path(self.source_dir), version, self))
             raise InstallationError(
-                'Source in %s has version %s that conflicts with %s'
-                % (display_path(self.source_dir), version, self))
+                'Source in {0!s} has version {1!s} that conflicts with {2!s}'.format(display_path(self.source_dir), version, self))
         else:
-            logger.debug('Source in %s has version %s, which satisfies requirement %s'
-                         % (display_path(self.source_dir), version, self))
+            logger.debug('Source in {0!s} has version {1!s}, which satisfies requirement {2!s}'.format(display_path(self.source_dir), version, self))
 
     def update_editable(self, obtain=True):
         if not self.url:
-            logger.info("Cannot update repository at %s; repository location is unknown" % self.source_dir)
+            logger.info("Cannot update repository at {0!s}; repository location is unknown".format(self.source_dir))
             return
         assert self.editable
         assert self.source_dir
         if self.url.startswith('file:'):
             # Static paths don't get updated
             return
-        assert '+' in self.url, "bad url: %r" % self.url
+        assert '+' in self.url, "bad url: {0!r}".format(self.url)
         if not self.update:
             return
         vc_type, url = self.url.split('+', 1)
@@ -386,8 +381,7 @@ exec(compile(open(__file__).read().replace('\\r\\n', '\\n'), __file__, 'exec'))
                 vcs_backend.export(self.source_dir)
         else:
             assert 0, (
-                'Unexpected version control type (in %s): %s'
-                % (self.url, vc_type))
+                'Unexpected version control type (in {0!s}): {1!s}'.format(self.url, vc_type))
 
     def uninstall(self, auto_confirm=False):
         """
@@ -403,7 +397,7 @@ exec(compile(open(__file__).read().replace('\\r\\n', '\\n'), __file__, 'exec'))
 
         """
         if not self.check_if_exists():
-            raise UninstallationError("Cannot uninstall requirement %s, not installed" % (self.name,))
+            raise UninstallationError("Cannot uninstall requirement {0!s}, not installed".format(self.name))
         dist = self.satisfied_by or self.conflicts_with
 
         paths_to_remove = UninstallPathSet(dist)
@@ -412,7 +406,7 @@ exec(compile(open(__file__).read().replace('\\r\\n', '\\n'), __file__, 'exec'))
                                          dist.egg_name()) + '.egg-info'
         # workaround for http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=618367
         debian_egg_info_path = pip_egg_info_path.replace(
-            '-py%s' % pkg_resources.PY_MAJOR, '')
+            '-py{0!s}'.format(pkg_resources.PY_MAJOR), '')
         easy_install_egg = dist.egg_name() + '.egg'
         develop_egg_link = egg_link_path(dist)
 
@@ -454,7 +448,7 @@ exec(compile(open(__file__).read().replace('\\r\\n', '\\n'), __file__, 'exec'))
             fh = open(develop_egg_link, 'r')
             link_pointer = os.path.normcase(fh.readline().strip())
             fh.close()
-            assert (link_pointer == dist.location), 'Egg-link %s does not match installed location of %s (at %s)' % (link_pointer, self.name, dist.location)
+            assert (link_pointer == dist.location), 'Egg-link {0!s} does not match installed location of {1!s} (at {2!s})'.format(link_pointer, self.name, dist.location)
             paths_to_remove.add(develop_egg_link)
             easy_install_pth = os.path.join(os.path.dirname(develop_egg_link),
                                             'easy-install.pth')
@@ -486,33 +480,29 @@ exec(compile(open(__file__).read().replace('\\r\\n', '\\n'), __file__, 'exec'))
         if self.uninstalled:
             self.uninstalled.rollback()
         else:
-            logger.error("Can't rollback %s, nothing uninstalled."
-                         % (self.project_name,))
+            logger.error("Can't rollback {0!s}, nothing uninstalled.".format(self.project_name))
 
     def commit_uninstall(self):
         if self.uninstalled:
             self.uninstalled.commit()
         else:
-            logger.error("Can't commit %s, nothing uninstalled."
-                         % (self.project_name,))
+            logger.error("Can't commit {0!s}, nothing uninstalled.".format(self.project_name))
 
     def archive(self, build_dir):
         assert self.source_dir
         create_archive = True
-        archive_name = '%s-%s.zip' % (self.name, self.installed_version)
+        archive_name = '{0!s}-{1!s}.zip'.format(self.name, self.installed_version)
         archive_path = os.path.join(build_dir, archive_name)
         if os.path.exists(archive_path):
-            response = ask('The file %s exists. (i)gnore, (w)ipe, (b)ackup '
-                           % display_path(archive_path), ('i', 'w', 'b'))
+            response = ask('The file {0!s} exists. (i)gnore, (w)ipe, (b)ackup '.format(display_path(archive_path)), ('i', 'w', 'b'))
             if response == 'i':
                 create_archive = False
             elif response == 'w':
-                logger.warn('Deleting %s' % display_path(archive_path))
+                logger.warn('Deleting {0!s}'.format(display_path(archive_path)))
                 os.remove(archive_path)
             elif response == 'b':
                 dest_file = backup_dir(archive_path)
-                logger.warn('Backing up %s to %s'
-                            % (display_path(archive_path), display_path(dest_file)))
+                logger.warn('Backing up {0!s} to {1!s}'.format(display_path(archive_path), display_path(dest_file)))
                 shutil.move(archive_path, dest_file)
         if create_archive:
             zip = zipfile.ZipFile(archive_path, 'w', zipfile.ZIP_DEFLATED)
@@ -534,11 +524,11 @@ exec(compile(open(__file__).read().replace('\\r\\n', '\\n'), __file__, 'exec'))
                     zip.write(filename, self.name + '/' + name)
             zip.close()
             logger.indent -= 2
-            logger.notify('Saved %s' % display_path(archive_path))
+            logger.notify('Saved {0!s}'.format(display_path(archive_path)))
 
     def _clean_zip_name(self, name, prefix):
         assert name.startswith(prefix+os.path.sep), (
-            "name %r doesn't start with prefix %r" % (name, prefix))
+            "name {0!r} doesn't start with prefix {1!r}".format(name, prefix))
         name = name[len(prefix)+1:]
         name = name.replace(os.path.sep, '/')
         return name
@@ -565,7 +555,7 @@ exec(compile(open(__file__).read().replace('\\r\\n', '\\n'), __file__, 'exec'))
                 install_args += ['--install-headers',
                                  os.path.join(sys.prefix, 'include', 'site',
                                               'python' + get_python_version())]
-            logger.notify('Running setup.py install for %s' % self.name)
+            logger.notify('Running setup.py install for {0!s}'.format(self.name))
             logger.indent += 2
             try:
                 call_subprocess(install_args + install_options,
@@ -573,7 +563,7 @@ exec(compile(open(__file__).read().replace('\\r\\n', '\\n'), __file__, 'exec'))
             finally:
                 logger.indent -= 2
             if not os.path.exists(record_filename):
-                logger.notify('Record file %s not found' % record_filename)
+                logger.notify('Record file {0!s} not found'.format(record_filename))
                 return
             self.install_succeeded = True
             f = open(record_filename)
@@ -583,7 +573,7 @@ exec(compile(open(__file__).read().replace('\\r\\n', '\\n'), __file__, 'exec'))
                     egg_info_dir = line
                     break
             else:
-                logger.warn('Could not find .egg-info directory in install record for %s' % self)
+                logger.warn('Could not find .egg-info directory in install record for {0!s}'.format(self))
                 ## FIXME: put the record somewhere
                 ## FIXME: should this be an error?
                 return
@@ -608,7 +598,7 @@ exec(compile(open(__file__).read().replace('\\r\\n', '\\n'), __file__, 'exec'))
         """Remove the source files from this requirement, if they are marked
         for deletion"""
         if self.is_bundle or os.path.exists(self.delete_marker_filename):
-            logger.info('Removing source in %s' % self.source_dir)
+            logger.info('Removing source in {0!s}'.format(self.source_dir))
             if self.source_dir:
                 rmtree(self.source_dir)
             self.source_dir = None
@@ -617,13 +607,13 @@ exec(compile(open(__file__).read().replace('\\r\\n', '\\n'), __file__, 'exec'))
         self._temp_build_dir = None
 
     def install_editable(self, install_options, global_options=()):
-        logger.notify('Running setup.py develop for %s' % self.name)
+        logger.notify('Running setup.py develop for {0!s}'.format(self.name))
         logger.indent += 2
         try:
             ## FIXME: should we do --install-headers here too?
             call_subprocess(
                 [sys.executable, '-c',
-                 "import setuptools; __file__=%r; exec(compile(open(__file__).read().replace('\\r\\n', '\\n'), __file__, 'exec'))" % self.setup_py]
+                 "import setuptools; __file__={0!r}; exec(compile(open(__file__).read().replace('\\r\\n', '\\n'), __file__, 'exec'))".format(self.setup_py)]
                 + list(global_options) + ['develop', '--no-deps'] + list(install_options),
 
                 cwd=self.source_dir, filter_stdout=self._filter_install,
@@ -686,7 +676,7 @@ exec(compile(open(__file__).read().replace('\\r\\n', '\\n'), __file__, 'exec'))
                     url, rev = vcs_backend().parse_vcs_bundle_file(content)
                     break
             if url:
-                url = '%s+%s@%s' % (vc_type, url, rev)
+                url = '{0!s}+{1!s}@{2!s}'.format(vc_type, url, rev)
             else:
                 url = None
             yield InstallRequirement(
@@ -713,11 +703,10 @@ exec(compile(open(__file__).read().replace('\\r\\n', '\\n'), __file__, 'exec'))
                     dest = os.path.join(dest_dir, dirname)
                     dir_collection.append(dest)
                     if os.path.exists(dest):
-                        logger.warn('The directory %s (containing package %s) already exists; cannot move source from bundle %s'
-                                    % (dest, dirname, self))
+                        logger.warn('The directory {0!s} (containing package {1!s}) already exists; cannot move source from bundle {2!s}'.format(dest, dirname, self))
                         continue
                     if not os.path.exists(dest_dir):
-                        logger.info('Creating directory %s' % dest_dir)
+                        logger.info('Creating directory {0!s}'.format(dest_dir))
                         os.makedirs(dest_dir)
                     shutil.move(os.path.join(source_dir, dirname), dest)
                 if not os.listdir(source_dir):
@@ -768,8 +757,8 @@ class Requirements(object):
         return self._dict[key]
 
     def __repr__(self):
-        values = [ '%s: %s' % (repr(k), repr(self[k])) for k in self.keys() ]
-        return 'Requirements({%s})' % ', '.join(values)
+        values = [ '{0!s}: {1!s}'.format(repr(k), repr(self[k])) for k in self.keys() ]
+        return 'Requirements({{{0!s}}})'.format(', '.join(values))
 
 
 class RequirementSet(object):
@@ -805,8 +794,7 @@ class RequirementSet(object):
         else:
             if self.has_requirement(name):
                 raise InstallationError(
-                    'Double requirement given: %s (aready in %s, name=%r)'
-                    % (install_req, self.get_requirement(name), name))
+                    'Double requirement given: {0!s} (aready in {1!s}, name={2!r})'.format(install_req, self.get_requirement(name), name))
             self.requirements[name] = install_req
             ## FIXME: what about other normalizations?  E.g., _ vs. -?
             if name.lower() != name:
@@ -839,8 +827,7 @@ class RequirementSet(object):
             else:
                 logger.fatal('Could not find download directory')
                 raise InstallationError(
-                    "Could not find or access download directory '%s'"
-                    % display_path(self.download_dir))
+                    "Could not find or access download directory '{0!s}'".format(display_path(self.download_dir)))
         return False
 
     def get_requirement(self, project_name):
@@ -849,7 +836,7 @@ class RequirementSet(object):
                 return self.requirements[name]
             if name in self.requirement_aliases:
                 return self.requirements[self.requirement_aliases[name]]
-        raise KeyError("No project with the name %r" % project_name)
+        raise KeyError("No project with the name {0!r}".format(project_name))
 
     def uninstall(self, auto_confirm=False):
         for req in self.requirements.values():
@@ -916,12 +903,12 @@ class RequirementSet(object):
                                   '(use --upgrade to upgrade): %s'
                                   % req_to_install)
             if req_to_install.editable:
-                logger.notify('Obtaining %s' % req_to_install)
+                logger.notify('Obtaining {0!s}'.format(req_to_install))
             elif install:
                 if req_to_install.url and req_to_install.url.lower().startswith('file:'):
-                    logger.notify('Unpacking %s' % display_path(url_to_path(req_to_install.url)))
+                    logger.notify('Unpacking {0!s}'.format(display_path(url_to_path(req_to_install.url))))
                 else:
-                    logger.notify('Downloading/unpacking %s' % req_to_install)
+                    logger.notify('Downloading/unpacking {0!s}'.format(req_to_install))
             logger.indent += 2
             try:
                 is_bundle = False
@@ -961,11 +948,9 @@ class RequirementSet(object):
                                 self.unpack_url(url, location, self.is_download)
                             except HTTPError:
                                 e = sys.exc_info()[1]
-                                logger.fatal('Could not install requirement %s because of error %s'
-                                             % (req_to_install, e))
+                                logger.fatal('Could not install requirement {0!s} because of error {1!s}'.format(req_to_install, e))
                                 raise InstallationError(
-                                    'Could not install requirement %s because of HTTP error %s for URL %s'
-                                    % (req_to_install, e, url))
+                                    'Could not install requirement {0!s} because of HTTP error {1!s} for URL {2!s}'.format(req_to_install, e, url))
                         else:
                             unpack = False
                     if unpack:
@@ -1013,7 +998,7 @@ class RequirementSet(object):
                             except ValueError:
                                 e = sys.exc_info()[1]
                                 ## FIXME: proper warning
-                                logger.error('Invalid requirement: %r (%s) in requirement %s' % (req, e, req_to_install))
+                                logger.error('Invalid requirement: {0!r} ({1!s}) in requirement {2!s}'.format(req, e, req_to_install))
                                 continue
                             if self.has_requirement(name):
                                 ## FIXME: check for conflict
@@ -1049,7 +1034,7 @@ class RequirementSet(object):
 
         for dir in remove_dir:
             if os.path.exists(dir):
-                logger.info('Removing temporary dir %s...' % dir)
+                logger.info('Removing temporary dir {0!s}...'.format(dir))
                 rmtree(dir)
 
         logger.indent -= 2
@@ -1060,10 +1045,10 @@ class RequirementSet(object):
 
     def copy_to_build_dir(self, req_to_install):
         target_dir = req_to_install.editable and self.src_dir or self.build_dir
-        logger.info("Copying %s to %s" % (req_to_install.name, target_dir))
+        logger.info("Copying {0!s} to {1!s}".format(req_to_install.name, target_dir))
         dest = os.path.join(target_dir, req_to_install.name)
         copytree(req_to_install.source_dir, dest)
-        call_subprocess(["python", "%s/setup.py" % dest, "clean"], cwd=dest,
+        call_subprocess(["python", "{0!s}/setup.py".format(dest), "clean"], cwd=dest,
                         command_desc='python setup.py clean')
 
     def unpack_url(self, link, location, only_download=False):
@@ -1084,13 +1069,12 @@ class RequirementSet(object):
                       if self.upgrade or not r.satisfied_by]
 
         if to_install:
-            logger.notify('Installing collected packages: %s' % ', '.join([req.name for req in to_install]))
+            logger.notify('Installing collected packages: {0!s}'.format(', '.join([req.name for req in to_install])))
         logger.indent += 2
         try:
             for requirement in to_install:
                 if requirement.conflicts_with:
-                    logger.notify('Found existing installation: %s'
-                                  % requirement.conflicts_with)
+                    logger.notify('Found existing installation: {0!s}'.format(requirement.conflicts_with))
                     logger.indent += 2
                     try:
                         requirement.uninstall(auto_confirm=True)
@@ -1172,17 +1156,17 @@ class RequirementSet(object):
         parts = [self.BUNDLE_HEADER]
         for req in [req for req in self.requirements.values()
                     if not req.comes_from]:
-            parts.append('%s==%s\n' % (req.name, req.installed_version))
+            parts.append('{0!s}=={1!s}\n'.format(req.name, req.installed_version))
         parts.append('# These packages were installed to satisfy the above requirements:\n')
         for req in [req for req in self.requirements.values()
                     if req.comes_from]:
-            parts.append('%s==%s\n' % (req.name, req.installed_version))
+            parts.append('{0!s}=={1!s}\n'.format(req.name, req.installed_version))
         ## FIXME: should we do something with self.unnamed_requirements?
         return ''.join(parts)
 
     def _clean_zip_name(self, name, prefix):
         assert name.startswith(prefix+os.path.sep), (
-            "name %r doesn't start with prefix %r" % (name, prefix))
+            "name {0!r} doesn't start with prefix {1!r}".format(name, prefix))
         name = name[len(prefix)+1:]
         name = name.replace(os.path.sep, '/')
         return name
@@ -1252,7 +1236,7 @@ def parse_requirements(filename, finder=None, comes_from=None, options=None):
             if finder:
                 finder.index_urls.append(line)
         else:
-            comes_from = '-r %s (line %s)' % (filename, line_number)
+            comes_from = '-r {0!s} (line {1!s})'.format(filename, line_number)
             if line.startswith('-e') or line.startswith('--editable'):
                 if line.startswith('-e'):
                     line = line[2:].strip()
@@ -1275,18 +1259,18 @@ def parse_editable(editable_req, default_vcs=None):
     if url.lower().startswith('file:'):
         return None, url
     for version_control in vcs:
-        if url.lower().startswith('%s:' % version_control):
-            url = '%s+%s' % (version_control, url)
+        if url.lower().startswith('{0!s}:'.format(version_control)):
+            url = '{0!s}+{1!s}'.format(version_control, url)
     if '+' not in url:
         if default_vcs:
             url = default_vcs + '+' + url
         else:
             raise InstallationError(
-                '--editable=%s should be formatted with svn+URL, git+URL, hg+URL or bzr+URL' % editable_req)
+                '--editable={0!s} should be formatted with svn+URL, git+URL, hg+URL or bzr+URL'.format(editable_req))
     vc_type = url.split('+', 1)[0].lower()
     if not vcs.get_backend(vc_type):
         raise InstallationError(
-            'For --editable=%s only svn (svn+URL), Git (git+URL), Mercurial (hg+URL) and Bazaar (bzr+URL) is currently supported' % editable_req)
+            'For --editable={0!s} only svn (svn+URL), Git (git+URL), Mercurial (hg+URL) and Bazaar (bzr+URL) is currently supported'.format(editable_req))
     match = re.search(r'(?:#|#.*?&)egg=([^&]*)', editable_req)
     if (not match or not match.group(1)) and vcs.get_backend(vc_type):
         parts = [p for p in editable_req.split('#', 1)[0].split('/') if p]
@@ -1296,8 +1280,7 @@ def parse_editable(editable_req, default_vcs=None):
             req = parts[-2]
         else:
             raise InstallationError(
-                '--editable=%s is not the right format; it must have #egg=Package'
-                % editable_req)
+                '--editable={0!s} is not the right format; it must have #egg=Package'.format(editable_req))
     else:
         req = match.group(1)
     ## FIXME: use package_to_requirement?
@@ -1329,8 +1312,7 @@ class UninstallPathSet(object):
 
     def _can_uninstall(self):
         if not dist_is_local(self.dist):
-            logger.notify("Not uninstalling %s at %s, outside environment %s"
-                          % (self.dist.project_name, normalize_path(self.dist.location), sys.prefix))
+            logger.notify("Not uninstalling {0!s} at {1!s}, outside environment {2!s}".format(self.dist.project_name, normalize_path(self.dist.location), sys.prefix))
             return False
         return True
 
@@ -1374,7 +1356,7 @@ class UninstallPathSet(object):
         ``auto_confirm`` is True)."""
         if not self._can_uninstall():
             return
-        logger.notify('Uninstalling %s:' % self.dist.project_name)
+        logger.notify('Uninstalling {0!s}:'.format(self.dist.project_name))
         logger.indent += 2
         paths = sorted(self.compact(self.paths))
         try:
@@ -1393,12 +1375,12 @@ class UninstallPathSet(object):
                                                  prefix='pip-')
                 for path in paths:
                     new_path = self._stash(path)
-                    logger.info('Removing file or directory %s' % path)
+                    logger.info('Removing file or directory {0!s}'.format(path))
                     self._moved_paths.append(path)
                     renames(path, new_path)
                 for pth in self.pth.values():
                     pth.remove()
-                logger.notify('Successfully uninstalled %s' % self.dist.project_name)
+                logger.notify('Successfully uninstalled {0!s}'.format(self.dist.project_name))
 
         finally:
             logger.indent -= 2
@@ -1406,12 +1388,12 @@ class UninstallPathSet(object):
     def rollback(self):
         """Rollback the changes previously made by remove()."""
         if self.save_dir is None:
-            logger.error("Can't roll back %s; was not uninstalled" % self.dist.project_name)
+            logger.error("Can't roll back {0!s}; was not uninstalled".format(self.dist.project_name))
             return False
-        logger.notify('Rolling back uninstall of %s' % self.dist.project_name)
+        logger.notify('Rolling back uninstall of {0!s}'.format(self.dist.project_name))
         for path in self._moved_paths:
             tmp_path = self._stash(path)
-            logger.info('Replacing %s' % path)
+            logger.info('Replacing {0!s}'.format(path))
             renames(tmp_path, path)
         for pth in self.pth:
             pth.rollback()
@@ -1427,7 +1409,7 @@ class UninstallPathSet(object):
 class UninstallPthEntries(object):
     def __init__(self, pth_file):
         if not os.path.isfile(pth_file):
-            raise UninstallationError("Cannot remove entries from nonexistent file %s" % pth_file)
+            raise UninstallationError("Cannot remove entries from nonexistent file {0!s}".format(pth_file))
         self.file = pth_file
         self.entries = set()
         self._saved_lines = None
@@ -1443,7 +1425,7 @@ class UninstallPthEntries(object):
         self.entries.add(entry)
 
     def remove(self):
-        logger.info('Removing pth entries from %s:' % self.file)
+        logger.info('Removing pth entries from {0!s}:'.format(self.file))
         fh = open(self.file, 'rb')
         # windows uses '\r\n' with py3k, but uses '\n' with py2.x
         lines = fh.readlines()
@@ -1455,7 +1437,7 @@ class UninstallPthEntries(object):
             endline = '\n'
         for entry in self.entries:
             try:
-                logger.info('Removing entry: %s' % entry)
+                logger.info('Removing entry: {0!s}'.format(entry))
                 lines.remove(b(entry + endline))
             except ValueError:
                 pass
@@ -1465,9 +1447,9 @@ class UninstallPthEntries(object):
 
     def rollback(self):
         if self._saved_lines is None:
-            logger.error('Cannot roll back changes to %s, none were made' % self.file)
+            logger.error('Cannot roll back changes to {0!s}, none were made'.format(self.file))
             return False
-        logger.info('Rolling %s back to previous state' % self.file)
+        logger.info('Rolling {0!s} back to previous state'.format(self.file))
         fh = open(self.file, 'wb')
         fh.writelines(self._saved_lines)
         fh.close()

--- a/jython-installer/src/main/resources/Lib/site-packages/pip/util.py
+++ b/jython-installer/src/main/resources/Lib/site-packages/pip/util.py
@@ -92,7 +92,7 @@ def find_command(cmd, paths=None, pathext=None):
                 return cmd_path_ext
         if os.path.isfile(cmd_path):
             return cmd_path
-    raise BadCommand('Cannot find command %r' % cmd)
+    raise BadCommand('Cannot find command {0!r}'.format(cmd))
 
 
 def get_pathext(default_pathext=None):
@@ -106,11 +106,11 @@ def ask(message, options):
     """Ask the message interactively, with the given possible responses"""
     while 1:
         if os.environ.get('PIP_NO_INPUT'):
-            raise Exception('No input was expected ($PIP_NO_INPUT set); question: %s' % message)
+            raise Exception('No input was expected ($PIP_NO_INPUT set); question: {0!s}'.format(message))
         response = raw_input(message)
         response = response.strip().lower()
         if response not in options:
-            print('Your response (%r) was not one of the expected responses: %s' % (
+            print('Your response ({0!r}) was not one of the expected responses: {1!s}'.format(
                 response, ', '.join(options)))
         else:
             return response
@@ -139,13 +139,13 @@ def normalize_name(name):
 
 def format_size(bytes):
     if bytes > 1000*1000:
-        return '%.1fMb' % (bytes/1000.0/1000)
+        return '{0:.1f}Mb'.format((bytes/1000.0/1000))
     elif bytes > 10*1000:
-        return '%iKb' % (bytes/1000)
+        return '{0:d}Kb'.format((bytes/1000))
     elif bytes > 1000:
-        return '%.1fKb' % (bytes/1000.0)
+        return '{0:.1f}Kb'.format((bytes/1000.0))
     else:
-        return '%ibytes' % bytes
+        return '{0:d}bytes'.format(bytes)
 
 
 def is_installable_dir(path):
@@ -405,7 +405,7 @@ def untar_file(filename, location):
     elif filename.lower().endswith('.tar'):
         mode = 'r'
     else:
-        logger.warn('Cannot determine compression type for file %s' % filename)
+        logger.warn('Cannot determine compression type for file {0!s}'.format(filename))
         mode = 'r:*'
     tar = tarfile.open(filename, mode)
     try:
@@ -432,8 +432,7 @@ def untar_file(filename, location):
                     # Some corrupt tar files seem to produce this
                     # (specifically bad symlinks)
                     logger.warn(
-                        'In the tar file %s the member %s is invalid: %s'
-                        % (filename, member.name, e))
+                        'In the tar file {0!s} the member {1!s} is invalid: {2!s}'.format(filename, member.name, e))
                     continue
                 if not os.path.exists(os.path.dirname(path)):
                     os.makedirs(os.path.dirname(path))
@@ -449,13 +448,13 @@ def untar_file(filename, location):
 
 def create_download_cache_folder(folder):
     logger.indent -= 2
-    logger.notify('Creating supposed download cache at %s' % folder)
+    logger.notify('Creating supposed download cache at {0!s}'.format(folder))
     logger.indent += 2
     os.makedirs(folder)
 
 
 def cache_download(target_file, temp_location, content_type):
-    logger.notify('Storing download in cache at %s' % display_path(target_file))
+    logger.notify('Storing download in cache at {0!s}'.format(display_path(target_file)))
     shutil.copyfile(temp_location, target_file)
     fp = open(target_file+'.content-type', 'w')
     fp.write(content_type)
@@ -481,9 +480,8 @@ def unpack_file(filename, location, content_type, link):
     else:
         ## FIXME: handle?
         ## FIXME: magic signatures?
-        logger.fatal('Cannot unpack file %s (downloaded from %s, content-type: %s); cannot detect archive format'
-                     % (filename, location, content_type))
-        raise InstallationError('Cannot determine archive format of %s' % location)
+        logger.fatal('Cannot unpack file {0!s} (downloaded from {1!s}, content-type: {2!s}); cannot detect archive format'.format(filename, location, content_type))
+        raise InstallationError('Cannot determine archive format of {0!s}'.format(location))
 
 
 

--- a/jython-installer/src/main/resources/Lib/site-packages/pip/vcs/__init__.py
+++ b/jython-installer/src/main/resources/Lib/site-packages/pip/vcs/__init__.py
@@ -41,7 +41,7 @@ class VcsSupport(object):
 
     def register(self, cls):
         if not hasattr(cls, 'name'):
-            logger.warn('Cannot register VCS %s' % cls.__name__)
+            logger.warn('Cannot register VCS {0!s}'.format(cls.__name__))
             return
         if cls.name not in self._registry:
             self._registry[cls.name] = cls
@@ -105,7 +105,7 @@ class VersionControl(object):
         if self._cmd is not None:
             return self._cmd
         command = find_command(self.name)
-        logger.info('Found command %r at %r' % (self.name, command))
+        logger.info('Found command {0!r} at {1!r}'.format(self.name, command))
         self._cmd = command
         return command
 
@@ -126,7 +126,7 @@ class VersionControl(object):
         """
         Returns (url, revision), where both are strings
         """
-        assert not location.rstrip('/').endswith(self.dirname), 'Bad directory: %s' % location
+        assert not location.rstrip('/').endswith(self.dirname), 'Bad directory: {0!s}'.format(location)
         return self.get_url(location), self.get_revision(location)
 
     def normalize_url(self, url):
@@ -182,39 +182,32 @@ class VersionControl(object):
             if os.path.exists(os.path.join(dest, self.dirname)):
                 existing_url = self.get_url(dest)
                 if self.compare_urls(existing_url, url):
-                    logger.info('%s in %s exists, and has correct URL (%s)'
-                                % (self.repo_name.title(), display_path(dest), url))
-                    logger.notify('Updating %s %s%s'
-                                  % (display_path(dest), self.repo_name, rev_display))
+                    logger.info('{0!s} in {1!s} exists, and has correct URL ({2!s})'.format(self.repo_name.title(), display_path(dest), url))
+                    logger.notify('Updating {0!s} {1!s}{2!s}'.format(display_path(dest), self.repo_name, rev_display))
                     self.update(dest, rev_options)
                 else:
-                    logger.warn('%s %s in %s exists with URL %s'
-                                % (self.name, self.repo_name, display_path(dest), existing_url))
+                    logger.warn('{0!s} {1!s} in {2!s} exists with URL {3!s}'.format(self.name, self.repo_name, display_path(dest), existing_url))
                     prompt = ('(s)witch, (i)gnore, (w)ipe, (b)ackup ', ('s', 'i', 'w', 'b'))
             else:
-                logger.warn('Directory %s already exists, and is not a %s %s.'
-                            % (dest, self.name, self.repo_name))
+                logger.warn('Directory {0!s} already exists, and is not a {1!s} {2!s}.'.format(dest, self.name, self.repo_name))
                 prompt = ('(i)gnore, (w)ipe, (b)ackup ', ('i', 'w', 'b'))
         if prompt:
-            logger.warn('The plan is to install the %s repository %s'
-                        % (self.name, url))
-            response = ask('What to do?  %s' % prompt[0], prompt[1])
+            logger.warn('The plan is to install the {0!s} repository {1!s}'.format(self.name, url))
+            response = ask('What to do?  {0!s}'.format(prompt[0]), prompt[1])
 
             if response == 's':
-                logger.notify('Switching %s %s to %s%s'
-                              % (self.repo_name, display_path(dest), url, rev_display))
+                logger.notify('Switching {0!s} {1!s} to {2!s}{3!s}'.format(self.repo_name, display_path(dest), url, rev_display))
                 self.switch(dest, url, rev_options)
             elif response == 'i':
                 # do nothing
                 pass
             elif response == 'w':
-                logger.warn('Deleting %s' % display_path(dest))
+                logger.warn('Deleting {0!s}'.format(display_path(dest)))
                 rmtree(dest)
                 checkout = True
             elif response == 'b':
                 dest_dir = backup_dir(dest)
-                logger.warn('Backing up %s to %s'
-                            % (display_path(dest), dest_dir))
+                logger.warn('Backing up {0!s} to {1!s}'.format(display_path(dest), dest_dir))
                 shutil.move(dest, dest_dir)
                 checkout = True
         return checkout
@@ -232,5 +225,5 @@ def get_src_requirement(dist, location, find_tags):
     version_control = vcs.get_backend_from_location(location)
     if version_control:
         return version_control().get_src_requirement(dist, location, find_tags)
-    logger.warn('cannot determine version of editable source in %s (is not SVN checkout, Git clone, Mercurial clone or Bazaar branch)' % location)
+    logger.warn('cannot determine version of editable source in {0!s} (is not SVN checkout, Git clone, Mercurial clone or Bazaar branch)'.format(location))
     return dist.as_requirement()

--- a/jython-installer/src/main/resources/Lib/site-packages/pip/vcs/bazaar.py
+++ b/jython-installer/src/main/resources/Lib/site-packages/pip/vcs/bazaar.py
@@ -54,13 +54,12 @@ class Bazaar(VersionControl):
         url, rev = self.get_url_rev()
         if rev:
             rev_options = ['-r', rev]
-            rev_display = ' (to revision %s)' % rev
+            rev_display = ' (to revision {0!s})'.format(rev)
         else:
             rev_options = []
             rev_display = ''
         if self.check_destination(dest, url, rev_options, rev_display):
-            logger.notify('Checking out %s%s to %s'
-                          % (url, rev_display, display_path(dest)))
+            logger.notify('Checking out {0!s}{1!s} to {2!s}'.format(url, rev_display, display_path(dest)))
             call_subprocess(
                 [self.cmd, 'branch', '-q'] + rev_options + [url, dest])
 
@@ -114,10 +113,10 @@ class Bazaar(VersionControl):
 
         if current_rev in tag_revs:
             # It's a tag
-            full_egg_name = '%s-%s' % (egg_project_name, tag_revs[current_rev])
+            full_egg_name = '{0!s}-{1!s}'.format(egg_project_name, tag_revs[current_rev])
         else:
-            full_egg_name = '%s-dev_r%s' % (dist.egg_name(), current_rev)
-        return '%s@%s#egg=%s' % (repo, current_rev, full_egg_name)
+            full_egg_name = '{0!s}-dev_r{1!s}'.format(dist.egg_name(), current_rev)
+        return '{0!s}@{1!s}#egg={2!s}'.format(repo, current_rev, full_egg_name)
 
 
 vcs.register(Bazaar)

--- a/jython-installer/src/main/resources/Lib/site-packages/pip/vcs/git.py
+++ b/jython-installer/src/main/resources/Lib/site-packages/pip/vcs/git.py
@@ -69,7 +69,7 @@ class Git(VersionControl):
         revisions.update(self.get_branch_revs(dest))
         inverse_revisions = dict((v, k) for k, v in revisions.items())
         # Check if rev is a branch name
-        origin_rev = 'origin/%s' % rev
+        origin_rev = 'origin/{0!s}'.format(rev)
         if origin_rev in inverse_revisions:
             # a remote tag or branch name
             return [inverse_revisions[origin_rev]]
@@ -77,7 +77,7 @@ class Git(VersionControl):
             # a local tag or branch name
             return [inverse_revisions[rev]]
         else:
-            logger.warn("Could not find a tag or branch '%s', assuming commit." % rev)
+            logger.warn("Could not find a tag or branch '{0!s}', assuming commit.".format(rev))
             return rev_options
 
     def switch(self, dest, url, rev_options):
@@ -98,12 +98,12 @@ class Git(VersionControl):
         url, rev = self.get_url_rev()
         if rev:
             rev_options = [rev]
-            rev_display = ' (to %s)' % rev
+            rev_display = ' (to {0!s})'.format(rev)
         else:
             rev_options = ['origin/master']
             rev_display = ''
         if self.check_destination(dest, url, rev_options, rev_display):
-            logger.notify('Cloning %s%s to %s' % (url, rev_display, display_path(dest)))
+            logger.notify('Cloning {0!s}{1!s} to {2!s}'.format(url, rev_display, display_path(dest)))
             call_subprocess([self.cmd, 'clone', '-q', url, dest])
             if rev:
                 rev_options = self.check_rev_options(rev, dest, rev_options)
@@ -161,16 +161,16 @@ class Git(VersionControl):
 
         if current_rev in tag_revs:
             # It's a tag
-            full_egg_name = '%s-%s' % (egg_project_name, tag_revs[current_rev])
+            full_egg_name = '{0!s}-{1!s}'.format(egg_project_name, tag_revs[current_rev])
         elif (current_rev in branch_revs and
               branch_revs[current_rev] != 'origin/master'):
             # It's the head of a branch
-            full_egg_name = '%s-%s' % (egg_project_name,
+            full_egg_name = '{0!s}-{1!s}'.format(egg_project_name,
                                        branch_revs[current_rev].replace('origin/', ''))
         else:
-            full_egg_name = '%s-dev' % egg_project_name
+            full_egg_name = '{0!s}-dev'.format(egg_project_name)
 
-        return '%s@%s#egg=%s' % (repo, current_rev, full_egg_name)
+        return '{0!s}@{1!s}#egg={2!s}'.format(repo, current_rev, full_egg_name)
 
     def get_url_rev(self):
         """

--- a/jython-installer/src/main/resources/Lib/site-packages/pip/vcs/mercurial.py
+++ b/jython-installer/src/main/resources/Lib/site-packages/pip/vcs/mercurial.py
@@ -57,8 +57,7 @@ class Mercurial(VersionControl):
         except (OSError, ConfigParser.NoSectionError):
             e = sys.exc_info()[1]
             logger.warn(
-                'Could not switch Mercurial repository to %s: %s'
-                % (url, e))
+                'Could not switch Mercurial repository to {0!s}: {1!s}'.format(url, e))
         else:
             call_subprocess([self.cmd, 'update', '-q'] + rev_options, cwd=dest)
 
@@ -71,13 +70,12 @@ class Mercurial(VersionControl):
         url, rev = self.get_url_rev()
         if rev:
             rev_options = [rev]
-            rev_display = ' (to revision %s)' % rev
+            rev_display = ' (to revision {0!s})'.format(rev)
         else:
             rev_options = []
             rev_display = ''
         if self.check_destination(dest, url, rev_options, rev_display):
-            logger.notify('Cloning hg %s%s to %s'
-                          % (url, rev_display, display_path(dest)))
+            logger.notify('Cloning hg {0!s}{1!s} to {2!s}'.format(url, rev_display, display_path(dest)))
             call_subprocess([self.cmd, 'clone', '--noupdate', '-q', url, dest])
             call_subprocess([self.cmd, 'update', '-q'] + rev_options, cwd=dest)
 
@@ -140,12 +138,12 @@ class Mercurial(VersionControl):
         branch_revs = self.get_branch_revs(location)
         if current_rev in tag_revs:
             # It's a tag
-            full_egg_name = '%s-%s' % (egg_project_name, tag_revs[current_rev])
+            full_egg_name = '{0!s}-{1!s}'.format(egg_project_name, tag_revs[current_rev])
         elif current_rev in branch_revs:
             # It's the tip of a branch
-            full_egg_name = '%s-%s' % (egg_project_name, branch_revs[current_rev])
+            full_egg_name = '{0!s}-{1!s}'.format(egg_project_name, branch_revs[current_rev])
         else:
-            full_egg_name = '%s-dev' % egg_project_name
-        return '%s@%s#egg=%s' % (repo, current_rev_hash, full_egg_name)
+            full_egg_name = '{0!s}-dev'.format(egg_project_name)
+        return '{0!s}@{1!s}#egg={2!s}'.format(repo, current_rev_hash, full_egg_name)
 
 vcs.register(Mercurial)

--- a/jython-installer/src/main/resources/Lib/site-packages/pip/vcs/subversion.py
+++ b/jython-installer/src/main/resources/Lib/site-packages/pip/vcs/subversion.py
@@ -23,19 +23,19 @@ class Subversion(VersionControl):
 
     def get_info(self, location):
         """Returns (url, revision), where both are strings"""
-        assert not location.rstrip('/').endswith(self.dirname), 'Bad directory: %s' % location
+        assert not location.rstrip('/').endswith(self.dirname), 'Bad directory: {0!s}'.format(location)
         output = call_subprocess(
             [self.cmd, 'info', location], show_stdout=False, extra_environ={'LANG': 'C'})
         match = _svn_url_re.search(output)
         if not match:
-            logger.warn('Cannot determine URL of svn checkout %s' % display_path(location))
-            logger.info('Output that cannot be parsed: \n%s' % output)
+            logger.warn('Cannot determine URL of svn checkout {0!s}'.format(display_path(location)))
+            logger.info('Output that cannot be parsed: \n{0!s}'.format(output))
             return None, None
         url = match.group(1).strip()
         match = _svn_revision_re.search(output)
         if not match:
-            logger.warn('Cannot determine revision of svn checkout %s' % display_path(location))
-            logger.info('Output that cannot be parsed: \n%s' % output)
+            logger.warn('Cannot determine revision of svn checkout {0!s}'.format(display_path(location)))
+            logger.info('Output that cannot be parsed: \n{0!s}'.format(output))
             return url, None
         return url, match.group(1)
 
@@ -54,7 +54,7 @@ class Subversion(VersionControl):
     def export(self, location):
         """Export the svn repository at the url to the destination location"""
         url, rev = self.get_url_rev()
-        logger.notify('Exporting svn repository %s to %s' % (url, location))
+        logger.notify('Exporting svn repository {0!s} to {1!s}'.format(url, location))
         logger.indent += 2
         try:
             if os.path.exists(location):
@@ -79,13 +79,12 @@ class Subversion(VersionControl):
         url, rev = self.get_url_rev()
         if rev:
             rev_options = ['-r', rev]
-            rev_display = ' (to revision %s)' % rev
+            rev_display = ' (to revision {0!s})'.format(rev)
         else:
             rev_options = []
             rev_display = ''
         if self.check_destination(dest, url, rev_options, rev_display):
-            logger.notify('Checking out %s%s to %s'
-                          % (url, rev_display, display_path(dest)))
+            logger.notify('Checking out {0!s}{1!s} to {2!s}'.format(url, rev_display, display_path(dest)))
             call_subprocess(
                 [self.cmd, 'checkout', '-q'] + rev_options + [url, dest])
 
@@ -167,8 +166,7 @@ class Subversion(VersionControl):
             location = os.path.dirname(location)
             if location == last_location:
                 # We've traversed up to the root of the filesystem without finding setup.py
-                logger.warn("Could not find setup.py for directory %s (tried all parent directories)"
-                            % orig_location)
+                logger.warn("Could not find setup.py for directory {0!s} (tried all parent directories)".format(orig_location))
                 return None
         f = open(os.path.join(location, self.dirname, 'entries'))
         data = f.read()
@@ -180,10 +178,10 @@ class Subversion(VersionControl):
         elif data.startswith('<?xml'):
             match = _svn_xml_url_re.search(data)
             if not match:
-                raise ValueError('Badly formatted data: %r' % data)
+                raise ValueError('Badly formatted data: {0!r}'.format(data))
             return match.group(1)    # get repository URL
         else:
-            logger.warn("Unrecognized .svn/entries format in %s" % location)
+            logger.warn("Unrecognized .svn/entries format in {0!s}".format(location))
             # Or raise exception?
             return None
 
@@ -220,25 +218,25 @@ class Subversion(VersionControl):
         rev = self.get_revision(location)
         if parts[-2] in ('tags', 'tag'):
             # It's a tag, perfect!
-            full_egg_name = '%s-%s' % (egg_project_name, parts[-1])
+            full_egg_name = '{0!s}-{1!s}'.format(egg_project_name, parts[-1])
         elif parts[-2] in ('branches', 'branch'):
             # It's a branch :(
-            full_egg_name = '%s-%s-r%s' % (dist.egg_name(), parts[-1], rev)
+            full_egg_name = '{0!s}-{1!s}-r{2!s}'.format(dist.egg_name(), parts[-1], rev)
         elif parts[-1] == 'trunk':
             # Trunk :-/
-            full_egg_name = '%s-dev_r%s' % (dist.egg_name(), rev)
+            full_egg_name = '{0!s}-dev_r{1!s}'.format(dist.egg_name(), rev)
             if find_tags:
                 tag_url = '/'.join(parts[:-1]) + '/tags'
                 tag_revs = self.get_tag_revs(tag_url)
                 match = self.find_tag_match(rev, tag_revs)
                 if match:
-                    logger.notify('trunk checkout %s seems to be equivalent to tag %s' % match)
-                    repo = '%s/%s' % (tag_url, match)
-                    full_egg_name = '%s-%s' % (egg_project_name, match)
+                    logger.notify('trunk checkout {0!s} seems to be equivalent to tag {1!s}'.format(*match))
+                    repo = '{0!s}/{1!s}'.format(tag_url, match)
+                    full_egg_name = '{0!s}-{1!s}'.format(egg_project_name, match)
         else:
             # Don't know what it is
-            logger.warn('svn URL does not fit normal structure (tags/branches/trunk): %s' % repo)
-            full_egg_name = '%s-dev_r%s' % (egg_project_name, rev)
-        return 'svn+%s@%s#egg=%s' % (repo, rev, full_egg_name)
+            logger.warn('svn URL does not fit normal structure (tags/branches/trunk): {0!s}'.format(repo))
+            full_egg_name = '{0!s}-dev_r{1!s}'.format(egg_project_name, rev)
+        return 'svn+{0!s}@{1!s}#egg={2!s}'.format(repo, rev, full_egg_name)
 
 vcs.register(Subversion)

--- a/jython-installer/src/main/resources/Lib/site-packages/pip/venv.py
+++ b/jython-installer/src/main/resources/Lib/site-packages/pip/venv.py
@@ -25,10 +25,10 @@ def restart_in_venv(venv, base, site_packages, args):
         try:
             import virtualenv
         except ImportError:
-            print('The virtual environment does not exist: %s' % venv)
+            print('The virtual environment does not exist: {0!s}'.format(venv))
             print('and virtualenv is not installed, so a new environment cannot be created')
             sys.exit(3)
-        print('Creating new virtualenv environment in %s' % venv)
+        print('Creating new virtualenv environment in {0!s}'.format(venv))
         virtualenv.logger = logger
         logger.indent += 2
         virtualenv.create_environment(venv, site_packages=site_packages)
@@ -42,7 +42,7 @@ def restart_in_venv(venv, base, site_packages, args):
     if not os.path.exists(python):
         python = venv
     if not os.path.exists(python):
-        raise BadCommand('Cannot find virtual environment interpreter at %s' % python)
+        raise BadCommand('Cannot find virtual environment interpreter at {0!s}'.format(python))
     base = os.path.dirname(os.path.dirname(python))
     file = os.path.join(os.path.dirname(__file__), 'runner.py')
     if file.endswith('.pyc'):


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:jython-plugin?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:runt18:jython-plugin?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
